### PR TITLE
implement of merkleTree's ComputeRoot func

### DIFF
--- a/crypto/merkleTree.go
+++ b/crypto/merkleTree.go
@@ -29,7 +29,6 @@ type MerkleTreeNode struct {
 	Hash  Uint256
 	Left  *MerkleTreeNode
 	Right *MerkleTreeNode
-	//Parent   *MerkleTreeNode
 }
 
 func (t *MerkleTreeNode) IsLeaf() bool {
@@ -69,7 +68,7 @@ func generateLeaves(hashes []Uint256) []*MerkleTreeNode {
 	return leaves
 }
 
-//calc the Parent's hash use double sha256
+//calc the next level's hash use double sha256
 func levelUp(nodes []*MerkleTreeNode) []*MerkleTreeNode {
 	var nextLevel []*MerkleTreeNode
 	for i := 0; i < len(nodes)/2; i++ {
@@ -100,13 +99,13 @@ func levelUp(nodes []*MerkleTreeNode) []*MerkleTreeNode {
 }
 
 //input a []uint256, create a MerkleTree & calc the root hash
-func ComputeRoot(hashes []Uint256) (*Uint256, error) {
+func ComputeRoot(hashes []Uint256) (Uint256, error) {
 	if len(hashes) == 0 {
-		return nil, NewDetailErr(errors.New("NewMerkleTree input no item error."), ErrNoCode, "")
+		return Uint256{}, NewDetailErr(errors.New("NewMerkleTree input no item error."), ErrNoCode, "")
 	}
 	if len(hashes) == 1 {
-		return &hashes[0], nil
+		return hashes[0], nil
 	}
 	tree, _ := NewMerkleTree(hashes)
-	return &tree.Root.Hash, nil
+	return tree.Root.Hash, nil
 }

--- a/crypto/merkleTree_test.go
+++ b/crypto/merkleTree_test.go
@@ -21,6 +21,6 @@ func TestHash(t *testing.T) {
 	data = append(data, a4)
 	data = append(data, a5)
 	x, _ := ComputeRoot(data)
-	fmt.Printf("[Root Hash]:%x\n", *x)
+	fmt.Printf("[Root Hash]:%x\n", x)
 
 }


### PR DESCRIPTION
implement of merkleTree's ComputeRoot func. 
Use double sha256 to generate the Parent's hash and finally get the root hash.

Have tested with c#Onchain's data and get the same root hash.
