### PR TITLE
Fix the compile error

### DIFF
--- a/core/transaction/transaction.go
+++ b/core/transaction/transaction.go
@@ -7,7 +7,6 @@ import (
 	sig "GoOnchain/core/signature"
 	"GoOnchain/core/transaction/payload"
 	. "GoOnchain/errors"
-	pl "GoOnchain/net/payload"
 	"crypto/sha256"
 	"errors"
 	"io"


### PR DESCRIPTION
The compile error is core/transaction/transaction.go:10:2: cannot
find package "GoOnchain/net/payload".
This is because the payload folder was changed to message folder.
It has the import msg "GoOnchain/net/message" so deleted that line:
pl "GoOnchain/net/payload".

Signed-off-by: Jin Qing <1091147665@qq.com>