### PR TITLE
Fix some compile error

### DIFF
--- a/core/ledger/block.go
+++ b/core/ledger/block.go
@@ -7,7 +7,7 @@ import (
 	tx "GoOnchain/core/transaction"
 	"GoOnchain/crypto"
 	. "GoOnchain/errors"
-	pl "GoOnchain/net/payload"
+	msg "GoOnchain/net/message"
 	"io"
 )
 
@@ -91,8 +91,8 @@ func (b *Block) Verify() error {
 	return nil
 }
 
-func (b *Block) InvertoryType() pl.InventoryType {
-	return pl.Block
+func (b *Block) InvertoryType() msg.InventoryType {
+	return msg.BLOCK
 }
 
 func (bc *Blockchain) GetBlock(height uint32) (*Block, error) {

--- a/core/store/LevelDBStore/LevelDBStore.go
+++ b/core/store/LevelDBStore/LevelDBStore.go
@@ -148,7 +148,7 @@ func (bd *LevelDBStore) GetContract(hash []byte) ([]byte, error) {
 	return bData,nil
 }
 
-func (bd *LevelDBStore) GetHeader(hash []byte) (*Header, error) {
+func (bd *LevelDBStore) GetHeader(hash Uint256) (*Header, error) {
 	// TODO: GET HEADER
 	var h * Header = new (Header)
 
@@ -205,7 +205,7 @@ func (bd *LevelDBStore) SaveTransaction(tx *tx.Transaction,height uint32) error 
 	// add transaction header prefix.
 	txhash.WriteByte( byte(DATA_Transaction) )
 	// get transaction hash
-	txHashValue := tx.Hash
+	txHashValue := tx.Hash()
 	txHashValue.Serialize(txhash)
 
 	fmt.Printf( "transaction header + hash: %x\n",  txhash )
@@ -245,7 +245,8 @@ func (bd *LevelDBStore) GetBlock(hash []byte) (*Block, error) {
 
 	// Deserialize transaction
 	for i:=0; i<len(b.Transcations); i++ {
-		bd.GetTransaction(b.Transcations[i],b.Transcations[i].Hash.ToArray())
+		hash := b.Transcations[i].Hash()
+		bd.GetTransaction(b.Transcations[i],hash.ToArray())
 	}
 
 	return b,err


### PR DESCRIPTION
block.go
>As the payload folder was changed to message folder.  so the block.go also need to be fixed as below.

LevelDBStore.go
>transaction.go does not have the Hash item(but has the 'hash' item),  so changed to use the Hash() function.

2017/02/08 by junjie