### PR TITLE
Add httpjson server to response client command

### DIFF
--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -70,3 +70,10 @@ type Tmper interface {
 	GetEvent(eventName string) *events.Event
 	Connect(nodeAddr string)
 }
+
+type JsonNoder interface {
+	GetConnectionCnt() uint
+	GetTxnPool() map[common.Uint256]*transaction.Transaction
+	Xmit(common.Inventory) error
+	GetTransaction(hash common.Uint256) *transaction.Transaction	
+}


### PR DESCRIPTION
According to the httpjson client request to send response to the
client.
So far it has ten commands responses as below,
getbestblockhash, getblock, getblockcount, getblockhash,
getconnectioncount, getrawmempool, getrawtransaction, gettxout,
sendrawtransaction, submitblock.

Signed-off-by: Jin Qing <1091147665@qq.com>