### PR TITLE
Complete EncodePoint function

### DIFF
--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -1,11 +1,23 @@
 package crypto
 
 import (
-	"io"
-	"errors"
-	//"math/big"
-	"crypto/rand"
+	. "GoOnchain/errors"
 	"crypto/ecdsa"
+	"crypto/rand"
+	"errors"
+	"io"
+	"math/big"
+)
+
+const (
+	INFINITYLEN      = 1
+	FLAGLEN          = 1
+	XORYVALUELEN     = 32
+	COMPRESSEDLEN    = 33
+	NOCOMPRESSEDLEN  = 65
+	COMPEVENFLAG     = 0x02
+	COMPODDFLAG      = 0x03
+	NOCOMPRESSEDFLAG = 0x04
 )
 
 type PubKey ECPoint
@@ -19,14 +31,62 @@ func (e *PubKey) DeSerialize(r io.Reader) error {
 	return nil
 }
 
-func (ep *PubKey) EncodePoint(commpressed bool) []byte{
-	//TODO: EncodePoint
-	return nil
+func reverse(data []byte) {
+	dataLen := len(data)
+	for i := 0; i < dataLen/2; i++ {
+		tmp := data[i]
+		data[i] = data[dataLen-i-1]
+		data[dataLen-i-1] = tmp
+	}
 }
 
-func NewPubKey(prikey []byte) *PubKey{
-       //TODO: NewPubKey
-       return nil
+func isEven(k *big.Int) bool {
+	z := big.NewInt(0)
+	z.Mod(k, big.NewInt(2))
+	if z.Int64() == 0 {
+		return true
+	}
+	return false
+}
+
+// EncodePoint is used for compressing PublicKey for less space used as same as which in bitcoin.
+func (e *PubKey) EncodePoint(isCommpressed bool) ([]byte, error) {
+	//if X is infinity, then Y cann't be computed, so here used "||"
+	if nil == e.X || nil == e.Y {
+		return nil, NewDetailErr(errors.New("The PubKey is an infinity point"), ErrNoCode, "")
+	}
+
+	var encodedData []byte
+
+	if isCommpressed {
+		encodedData = make([]byte, COMPRESSEDLEN)
+	} else {
+		encodedData = make([]byte, NOCOMPRESSEDLEN)
+
+		yBytes := e.Y.Bytes()
+		copy(encodedData[NOCOMPRESSEDLEN-len(yBytes):], yBytes)
+		reverse(encodedData[XORYVALUELEN+FLAGLEN:])
+	}
+
+	xBytes := e.X.Bytes()
+	copy(encodedData[FLAGLEN:COMPRESSEDLEN], xBytes)
+	reverse(encodedData[FLAGLEN : FLAGLEN+XORYVALUELEN])
+
+	if isCommpressed {
+		if isEven(e.Y) {
+			encodedData[0] = COMPEVENFLAG
+		} else {
+			encodedData[0] = COMPODDFLAG
+		}
+	} else {
+		encodedData[0] = NOCOMPRESSEDFLAG
+	}
+	return encodedData, nil
+}
+
+func NewPubKey(prikey []byte) *PubKey {
+	//TODO: NewPubKey
+	return nil
 }
 
 func GenPrivKey() []byte {
@@ -49,14 +109,14 @@ func GenKeyPair() ([]byte, PubKey, error) {
 	return privkey, *pubkey, nil
 }
 
-func DecodePoint(encoded []byte) *PubKey{
+func DecodePoint(encoded []byte) *PubKey {
 	//TODO: DecodePoint
 	return nil
 }
 
 type PubKeySlice []*PubKey
 
-func (p PubKeySlice) Len() int           { return len(p) }
+func (p PubKeySlice) Len() int { return len(p) }
 func (p PubKeySlice) Less(i, j int) bool {
 	//TODO:PubKeySlice Less
 	return false


### PR DESCRIPTION
The function of "EncodePoint" is used for compressing PublicKey
for less space used as same as which in bitcoin, and the process
is as follow:
If the choice of "compressed" is true, "EncodePoint" will reverse
X's value of PublicKey, and judge the value of Y. If Y is an even
number, a byte of "0x02" will be added before the value of X which
is already reversed, otherwise, 0x03 instead.
If the choice of "compressed" is false, the return value will be:
0x04 + X' + Y' ( X' and Y' were obtained by reversing the value of
X and Y).

Signed-off-by: XiaoJie Guo <guoxiaojie@onchain.com>