### PR TITLE
Change node Xmit function

### DIFF
--- a/net/message/blockHdr.go
+++ b/net/message/blockHdr.go
@@ -116,7 +116,7 @@ func (msg headersReq) Handle(node Noder) error {
 	stophash = msg.p.hashEnd
 	//FIXME if HeaderHashCount > 1
 	buf, _ := NewHeaders(starthash, stophash) //(starthash[0], stophash)
-	go node.LocalNode().Tx(buf)
+	go node.Tx(buf)
 	return nil
 }
 
@@ -161,7 +161,7 @@ func NewHeaders(starthash common.Uint256, stophash common.Uint256) ([]byte, erro
 	*/
 	msg.hdr.Magic = NETMAGIC
 	cmd := "headers"
-	copy(msg.hdr.CMD[0:7], cmd)
+	copy(msg.hdr.CMD[0:len(cmd)], cmd)
 	b := new(bytes.Buffer)
 	err := binary.Write(b, binary.LittleEndian, &(msg.blkHdr))
 	if err != nil {

--- a/net/node/link.go
+++ b/net/node/link.go
@@ -31,7 +31,7 @@ type link struct {
 func unpackNodeBuf(node *node, buf []byte) {
 	var msgLen int
 	var msgBuf []byte
-
+	common.Trace()
 	if node.rxBuf.p == nil {
 		if len(buf) < MSGHDRLEN {
 			fmt.Println("Unexpected size of received message")
@@ -45,7 +45,7 @@ func unpackNodeBuf(node *node, buf []byte) {
 		msgLen = node.rxBuf.len
 	}
 
-	//fmt.Printf("The msg length is %d, buf len is %d\n", msgLen, len(buf))
+	fmt.Printf("The msg length is %d, buf len is %d\n", msgLen, len(buf))
 	if len(buf) == msgLen {
 		msgBuf = append(node.rxBuf.p, buf[:]...)
 		go HandleNodeMsg(node, msgBuf, len(msgBuf))


### PR DESCRIPTION
The node Xmit can send three types inventory, such as block,
tx and consusens. So change build the new inventory message
in every message file: block.go, transaction.go and consusens.go.

Signed-off-by: Jin Qing <1091147665@qq.com>