### PR TITLE
Remove the comments for transaction and blockHdr

### DIFF
--- a/net/message/blockHdr.go
+++ b/net/message/blockHdr.go
@@ -134,31 +134,32 @@ func GetHeadersFromHash(starthash common.Uint256, stophash common.Uint256) ([]le
 	var count uint32 = 0
 	var empty [HASHLEN]byte
 	var headers []ledger.Blockdata
-	bkstart, _ := ledger.DefaultLedger.Store.GetBlock(starthash)
+	bkstart, _ := ledger.DefaultLedger.GetBlockWithHash(starthash)
 	startheight := bkstart.Blockdata.Height
 	var stopheight uint32
 	if stophash != empty {
-		bkstop, _ := ledger.DefaultLedger.Store.GetBlock(starthash)
+		bkstop, _ := ledger.DefaultLedger.GetBlockWithHash(stophash)
 		stopheight = bkstop.Blockdata.Height
 		count = startheight - stopheight
 		if count >= 2000 {
 			count = 2000
+			stopheight = startheight - 20000
 		}
 	} else {
 		count = 2000
 	}
 
 	// waiting for GetBlockWithHeight commit
-	/*
-		var i uint32
 
-		for i = 1; i <= count; i++ {
-			//FIXME need add error handle for GetBlockWithHeight
-			bk, _ := ledger.DefaultLedger.Blockchain.GetBlockWithHeight(stopheight + i)
-			headers = append(headers, bk.Blockdata)
-			i++
-		}
-	*/
+	var i uint32
+
+	for i = 1; i <= count; i++ {
+		//FIXME need add error handle for GetBlockWithHeight
+		bk, _ := ledger.DefaultLedger.GetBlockWithHeight(stopheight + i)
+		headers = append(headers, *bk.Blockdata)
+		i++
+	}
+
 	return headers, count
 }
 

--- a/net/message/transaction.go
+++ b/net/message/transaction.go
@@ -2,9 +2,9 @@ package message
 
 import (
 	"GoOnchain/common"
+	"GoOnchain/core/ledger"
 	"GoOnchain/core/transaction"
 	. "GoOnchain/net/protocol"
-	//"GoOnchain/core/ledger"
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
@@ -31,7 +31,7 @@ type trn struct {
 func (msg trn) Handle(node Noder) error {
 	common.Trace()
 	fmt.Printf("RX TRX message\n")
-	
+
 	if !node.LocalNode().ExistedID(msg.txn.Hash()) {
 		node.LocalNode().AppendTxnPool(&(msg.txn))
 	}
@@ -73,13 +73,10 @@ func (msg *dataReq) Deserialization(p []byte) error {
 }
 
 func NewTxFromHash(hash common.Uint256) *transaction.Transaction {
-	/*
-		trx, _ := ledger.DefaultLedger.Blockchain.GetTransactionWithHash(hash)
-		txBuffer := bytes.NewBuffer([]byte{})
-		trx.Serialize(txBuffer)
-		msg.txn = txBuffer.Bytes()
-	*/
-	var trx *transaction.Transaction
+
+	trx, _ := ledger.DefaultLedger.GetTransactionWithHash(hash)
+
+	//var trx *transaction.Transaction
 	return trx
 }
 func NewTx(trx *transaction.Transaction) ([]byte, error) {
@@ -133,7 +130,6 @@ func (msg trn) Serialization() ([]byte, error) {
 	return buf.Bytes(), err
 }
 
-
 func (msg trn) DeSerialization(p []byte) error {
 	buf := bytes.NewBuffer(p)
 	err := binary.Read(buf, binary.LittleEndian, &(msg.msgHdr))
@@ -144,4 +140,3 @@ func (msg trn) DeSerialization(p []byte) error {
 
 	return nil
 }
-


### PR DESCRIPTION
Remove the comments for transaction and blockHdr,
since the GetBlockWithHash function and GetTransactionWithHash
had committed.

Signed-off-by: Jin Qing <1091147665@qq.com>