### PR TITLE
Add the time delay to keep the message sequence for handshaking

### DIFF
--- a/net/message/version.go
+++ b/net/message/version.go
@@ -154,6 +154,7 @@ func (msg version) Handle(node Noder) error {
 	buf, _ := NewVersion(localNode)
 	node.Tx(buf)
 
+	time.Sleep(2 * time.Second)
 	buf, _ = NewVerack()
 	node.Tx(buf)
 

--- a/net/node/link.go
+++ b/net/node/link.go
@@ -167,6 +167,7 @@ func (node *node) Connect(nodeAddr string) {
 			conn.RemoteAddr().Network())
 		go n.rx()
 
+		time.Sleep(2 * time.Second)
 		// FIXME is there any timing race with rx
 		buf, _ := NewVersion(node)
 		n.Tx(buf)


### PR DESCRIPTION
    The hankshake message need keep special sequence to finished the
    process. Here we add the time delay between message to keep
    this sequence