### PR TITLE
Add Glide package manager tool

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -8,9 +8,7 @@ import (
 	"fmt"
 	_ "io"
 	"math/rand"
-
-	"golang.org/x/crypto/ripemd160"
-	//"GoOnchain/common/log"
+	"github.com/golang/crypto/ripemd160"
 	"encoding/hex"
 	"errors"
 	"io"

--- a/common/uint160.go
+++ b/common/uint160.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"crypto/sha256"
 	"math/big"
-	"golang.org/x/crypto/base58"
+	"github.com/tv42/base58"
 	."GoOnchain/errors"
 	"errors"
 )

--- a/core/transaction/transaction.go
+++ b/core/transaction/transaction.go
@@ -6,7 +6,6 @@ import (
 	"GoOnchain/core/contract"
 	"GoOnchain/core/contract/program"
 	sig "GoOnchain/core/signature"
-	msg "GoOnchain/node/message"
 	"GoOnchain/core/transaction/payload"
 	. "GoOnchain/errors"
 	"crypto/sha256"

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,27 @@
+hash: 4240fb61a05482ff3f31f9726cc69aaf288fe658c5e31db30d27e4e6bc74210c
+updated: 2017-03-22T19:10:43.050363339+08:00
+imports:
+- name: github.com/golang/crypto
+  version: 459e26527287adbc2adcc5d0d49abff9a5f315a7
+  subpackages:
+  - ripemd160
+- name: github.com/golang/snappy
+  version: 553a641470496b2327abcac10b36396bd98e45c9
+- name: github.com/syndtr/goleveldb
+  version: 3c5717caf1475fd25964109a0fc640bd150fce43
+  subpackages:
+  - leveldb
+  - leveldb/cache
+  - leveldb/comparer
+  - leveldb/errors
+  - leveldb/filter
+  - leveldb/iterator
+  - leveldb/journal
+  - leveldb/memdb
+  - leveldb/opt
+  - leveldb/storage
+  - leveldb/table
+  - leveldb/util
+- name: github.com/tv42/base58
+  version: b6649477bfe6276322b4eeaae8f5e947b49cec92
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,12 @@
+package: GoOnchain
+import:
+- package: github.com/golang/crypto
+  subpackages:
+  - ripemd160
+- package: github.com/syndtr/goleveldb
+  subpackages:
+  - leveldb
+  - leveldb/errors
+  - leveldb/iterator
+  - leveldb/opt
+- package: github.com/tv42/base58

--- a/net/message/blockHdr.go
+++ b/net/message/blockHdr.go
@@ -30,9 +30,7 @@ type blkHeader struct {
 func NewHeadersReq(n Noder) ([]byte, error) {
 	var h headersReq
 
-	// Fixme correct with the exactly request length
 	h.p.len = 1
-	//Fixme! Should get the remote Node height.
 	buf := ledger.DefaultLedger.Blockchain.CurrentBlockHash()
 	copy(h.p.hashStart[:], reverse(buf[:]))
 


### PR DESCRIPTION
The Glide package manager could automatic download the dependency
package what we need in this project, the third party package will
be remove from the project now to keep the code clean and tidy.

All the later compile need run "glide up" when download the code at
the first time

Signed-off-by: Yanbo Li <dreamfly281@gmail.com>