### PR TITLE
fix vm verify multi signature bug

### DIFF
--- a/vm/func_crypto.go
+++ b/vm/func_crypto.go
@@ -62,7 +62,7 @@ func opCheckMultiSig(e *ExecutionEngine) (VMState, error) {
 	}
 
 	signatures := make([][]byte, m)
-	for i := 0; i < n; i++ {
+	for i := 0; i < m; i++ {
 		signatures[i] = AssertStackItem(e.evaluationStack.Pop()).GetByteArray()
 	}
 

--- a/vm/func_crypto.go
+++ b/vm/func_crypto.go
@@ -71,9 +71,6 @@ func opCheckMultiSig(e *ExecutionEngine) (VMState, error) {
 
 	for i, j := 0, 0; fSuccess && i < m && j < n; {
 		ver, _ := e.crypto.VerifySignature(message, signatures[i], pubkeys[j])
-		//if err != nil {
-		//	return FAULT, err
-		//}
 		if ver {
 			i++
 		}

--- a/vm/func_crypto.go
+++ b/vm/func_crypto.go
@@ -70,10 +70,10 @@ func opCheckMultiSig(e *ExecutionEngine) (VMState, error) {
 	fSuccess := true
 
 	for i, j := 0, 0; fSuccess && i < m && j < n; {
-		ver, err := e.crypto.VerifySignature(message, signatures[i], pubkeys[j])
-		if err != nil {
-			return FAULT, err
-		}
+		ver, _ := e.crypto.VerifySignature(message, signatures[i], pubkeys[j])
+		//if err != nil {
+		//	return FAULT, err
+		//}
 		if ver {
 			i++
 		}


### PR DESCRIPTION
Fix vm verify multi signature bug

1.When get signature list from vm stack, should use the signature list length for the loop. (there is a mistake in previous code).
2.Verify the signature failure doesn't need to return verify fail, because when verify the multiple signature only need to guarantee that equal the number of the signature and public key is verified successfully.For example, three signatures just need three of the four public key is verified successfully, it is unnecessary verify all successful.
