### PR TITLE
leveldbstore modify AddHeaders() & persistBlocks()

### DIFF
--- a/core/ledger/block.go
+++ b/core/ledger/block.go
@@ -2,16 +2,16 @@ package ledger
 
 import (
 	. "DNA/common"
+	"DNA/common/log"
 	"DNA/common/serialization"
 	"DNA/core/contract/program"
-	tx "DNA/core/transaction"
 	sig "DNA/core/signature"
+	tx "DNA/core/transaction"
 	"DNA/crypto"
 	. "DNA/errors"
+	"DNA/vm"
 	"io"
 	"time"
-	"DNA/vm"
-	"DNA/common/log"
 )
 
 type Block struct {
@@ -109,7 +109,7 @@ func (b *Block) FromTrimmedData(r io.Reader) error {
 }
 
 func (b *Block) GetMessage() []byte {
-	return  sig.GetHashForSigning(b)
+	return sig.GetHashForSigning(b)
 }
 
 func (b *Block) GetProgramHashes() ([]Uint160, error) {
@@ -143,20 +143,20 @@ func (b *Block) Type() InventoryType {
 	return BLOCK
 }
 
-func GenesisBlockInit(miners []*crypto.PubKey) (*Block,error){
+func GenesisBlockInit() (*Block, error) {
 	genesisBlock := new(Block)
 	//blockdata
 	genesisBlockdata := new(Blockdata)
 	genesisBlockdata.Version = uint32(0x00)
 	genesisBlockdata.PrevBlockHash = Uint256{}
 	genesisBlockdata.TransactionsRoot = Uint256{}
-	tm:=time.Date(2017, time.February, 23, 0, 0, 0, 0, time.UTC)
+	tm := time.Date(2017, time.February, 23, 0, 0, 0, 0, time.UTC)
 	genesisBlockdata.Timestamp = uint32(tm.Unix())
 	genesisBlockdata.Height = uint32(0)
 	genesisBlockdata.ConsensusData = uint64(2083236893)
-	nextMiner, err := GetMinerAddress(miners)
-	if err != nil{
-		return nil,NewDetailErr(err, ErrNoCode, "[Block],GenesisBlockInit err with GetMinerAddress")
+	nextMiner, err := GetMinerAddress(StandbyMiners)
+	if err != nil {
+		return nil, NewDetailErr(err, ErrNoCode, "[Block],GenesisBlockInit err with GetMinerAddress")
 	}
 	genesisBlockdata.NextMiner = nextMiner
 
@@ -187,43 +187,24 @@ func GenesisBlockInit(miners []*crypto.PubKey) (*Block,error){
 	}
 	genesisBlock.Blockdata = genesisBlockdata
 
-	genesisBlock.Transactions = append(genesisBlock.Transactions,trans)
+	genesisBlock.Transactions = append(genesisBlock.Transactions, trans)
 
 	//hashx := genesisBlock.Hash()
 
-	return genesisBlock,nil
+	return genesisBlock, nil
 }
 
-func CreateGenesisBlock(miners []*crypto.PubKey) error {
-	genesisBlock, err := GenesisBlockInit(miners)
-	if err != nil {
-		log.Error("Init Genesis Block Error")
-		return err
-	}
-	err = genesisBlock.RebuildMerkleRoot()
-	if err != nil {
-		return err
-	}
-	hashx := genesisBlock.Hash()
-	genesisBlock.hash = &hashx
-	DefaultLedger.Store.InitLevelDBStoreWithGenesisBlock(genesisBlock)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (b *Block)RebuildMerkleRoot()(error){
+func (b *Block) RebuildMerkleRoot() error {
 	txs := b.Transactions
 	transactionHashes := []Uint256{}
-	for _, tx :=  range txs{
-		transactionHashes = append(transactionHashes,tx.Hash())
+	for _, tx := range txs {
+		transactionHashes = append(transactionHashes, tx.Hash())
 	}
-	hash,err := crypto.ComputeRoot(transactionHashes)
-	if err!=nil{
+	hash, err := crypto.ComputeRoot(transactionHashes)
+	if err != nil {
 		return NewDetailErr(err, ErrNoCode, "[Block] , RebuildMerkleRoot ComputeRoot failed.")
 	}
-	b.Blockdata.TransactionsRoot =hash
+	b.Blockdata.TransactionsRoot = hash
 	return nil
 
 }

--- a/core/ledger/blockchain.go
+++ b/core/ledger/blockchain.go
@@ -3,6 +3,8 @@ package ledger
 import (
 	. "DNA/common"
 	"DNA/common/log"
+	tx "DNA/core/transaction"
+	"DNA/crypto"
 	. "DNA/errors"
 	"DNA/events"
 	"sync"
@@ -19,6 +21,20 @@ func NewBlockchain() *Blockchain {
 		BlockHeight: 0,
 		BCEvents:    events.NewEvent(),
 	}
+}
+
+func NewBlockchainWithGenesisBlock() (*Blockchain, error) {
+	blockchain := NewBlockchain()
+	genesisBlock, err := GenesisBlockInit()
+	if err != nil {
+		return nil, NewDetailErr(err, ErrNoCode, "[Blockchain], NewBlockchainWithGenesisBlock failed.")
+	}
+	genesisBlock.RebuildMerkleRoot()
+	hashx := genesisBlock.Hash()
+	genesisBlock.hash = &hashx
+	//blockchain.AddBlock(genesisBlock)
+	DefaultLedger.Store.InitLevelDBStoreWithGenesisBlock(genesisBlock)
+	return blockchain, nil
 }
 
 func (bc *Blockchain) AddBlock(block *Block) error {
@@ -56,6 +72,7 @@ func (bc *Blockchain) GetHeader(hash Uint256) (*Header, error) {
 
 func (bc *Blockchain) SaveBlock(block *Block) error {
 	log.Trace()
+	log.Info("block hash ", block.Hash())
 	err := DefaultLedger.Store.SaveBlock(block, DefaultLedger)
 	if err != nil {
 		log.Warn("Save block failure ,err= ", err)
@@ -72,6 +89,20 @@ func (bc *Blockchain) ContainsTransaction(hash Uint256) bool {
 		return false
 	}
 	return true
+}
+
+func (bc *Blockchain) GetMinersByTXs(others []*tx.Transaction) []*crypto.PubKey {
+	//TODO: GetMiners()
+	//TODO: Just for TestUse
+
+	return StandbyMiners
+}
+
+func (bc *Blockchain) GetMiners() []*crypto.PubKey {
+	//TODO: GetMiners()
+	//TODO: Just for TestUse
+
+	return StandbyMiners
 }
 
 func (bc *Blockchain) CurrentBlockHash() Uint256 {

--- a/core/ledger/blockchain.go
+++ b/core/ledger/blockchain.go
@@ -61,7 +61,6 @@ func (bc *Blockchain) SaveBlock(block *Block) error {
 		log.Warn("Save block failure ,err= ", err)
 		return err
 	}
-	bc.BCEvents.Notify(events.EventBlockPersistCompleted, block)
 
 	return nil
 }

--- a/core/ledger/ledgerStore.go
+++ b/core/ledger/ledgerStore.go
@@ -14,7 +14,8 @@ type ILedgerStore interface {
 	GetBlockHash(height uint32) (Uint256, error)
 	InitLedgerStore(ledger *Ledger) error
 
-	SaveHeader(header *Header,ledger *Ledger) error
+	//SaveHeader(header *Header,ledger *Ledger) error
+	AddHeaders(headers []Blockdata, ledger *Ledger) error
 	GetHeader(hash Uint256) (*Header, error)
 
 	GetTransaction(hash Uint256) (*tx.Transaction,error)
@@ -27,5 +28,6 @@ type ILedgerStore interface {
 	Close() error
 
 	InitLevelDBStoreWithGenesisBlock( genesisblock * Block  )
-	GetQuantityIssued (AssetId Uint256) (*Fixed64, error)
+
+	GetQuantityIssued(AssetId Uint256) (*Fixed64, error)
 }

--- a/core/ledger/ledgerStore.go
+++ b/core/ledger/ledgerStore.go
@@ -15,7 +15,7 @@ type ILedgerStore interface {
 	InitLedgerStore(ledger *Ledger) error
 
 	//SaveHeader(header *Header,ledger *Ledger) error
-	AddHeaders(headers []Blockdata, ledger *Ledger) error
+	AddHeaders(headers []Header, ledger *Ledger) error
 	GetHeader(hash Uint256) (*Header, error)
 
 	GetTransaction(hash Uint256) (*tx.Transaction,error)

--- a/core/store/LevelDBStore/LevelDBStore.go
+++ b/core/store/LevelDBStore/LevelDBStore.go
@@ -10,6 +10,7 @@ import (
 	tx "DNA/core/transaction"
 	"DNA/core/transaction/payload"
 	"DNA/core/validation"
+	"DNA/events"
 	. "DNA/errors"
 	"bytes"
 	"fmt"
@@ -25,13 +26,14 @@ type LevelDBStore struct {
 	it *Iterator
 
 	header_index map[uint32]Uint256
-	//header_cache map[Uint256]*Blockdata
 	block_cache map[Uint256]*Block
 
 	current_block_height uint32
 	stored_header_count  uint32
 
 	mutex sync.Mutex
+
+	disposed bool
 }
 
 func init() {
@@ -55,13 +57,13 @@ func NewLevelDBStore(file string) (*LevelDBStore, error) {
 	}
 
 	return &LevelDBStore{
-		db:           db,
-		b:            nil,
-		it:           nil,
-		header_index: map[uint32]Uint256{},
-		//header_cache: map[Uint256]*Blockdata{},
-		block_cache:          map[Uint256]*Block{},
-		current_block_height: 0,
+		db:           		db,
+		b:            		nil,
+		it:           		nil,
+		header_index: 		map[uint32]Uint256{},
+		block_cache:          	map[Uint256]*Block{},
+		current_block_height: 	0,
+		disposed:		false,
 	}, nil
 }
 
@@ -183,6 +185,38 @@ func (bd *LevelDBStore) GetContract(hash []byte) ([]byte, error) {
 	return bData, nil
 }
 
+func (bd *LevelDBStore) AddHeaders(headers []Blockdata, ledger *Ledger) error {
+	bd.mutex.Lock()
+	defer bd.mutex.Unlock()
+
+	batch := new(leveldb.Batch)
+	for i:=0; i<len(headers); i++ {
+		if headers[i].Height-uint32(len(bd.header_index)) >= 1 {
+			break
+		}
+
+		if headers[i].Height < uint32(len(bd.header_index)) {
+			continue
+		}
+
+		//header verify
+		err := validation.VerifyBlockData(&headers[i], ledger)
+		if err != nil {
+			break
+		}
+
+		bd.onAddHeader(&headers[i], batch)
+	}
+
+	err := bd.db.Write(batch, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+/*
 func (bd *LevelDBStore) SaveHeader(header *Header, ledger *Ledger) error {
 	bd.mutex.Lock()
 	defer bd.mutex.Unlock()
@@ -209,52 +243,8 @@ func (bd *LevelDBStore) SaveHeader(header *Header, ledger *Ledger) error {
 	}
 
 	return nil
-
-	/*
-		//////////////////////////////////////////////////////////////
-		// generate key with DATA_Header prefix
-		headerkey := bytes.NewBuffer(nil)
-		// add header prefix.
-		headerkey.WriteByte( byte(DATA_Header) )
-		// contact block hash
-		blockhash := header.Blockdata.Hash()
-		blockhash.Serialize(headerkey)
-
-		fmt.Printf( "header key: %x\n",  headerkey )
-
-		// generate value
-		w := bytes.NewBuffer(nil)
-		header.Serialize(w)
-		fmt.Printf( "header data: %x\n",  w )
-
-		// PUT VALUE
-		err := bd.Put( headerkey.Bytes(), w.Bytes() )
-		if ( err != nil ){
-			return err
-		}
-
-		//////////////////////////////////////////////////////////////
-		// generate key with DATA_BlockHash prefix
-		bhash := bytes.NewBuffer(nil)
-		bhash.WriteByte( byte(DATA_BlockHash) )
-		err = serialization.WriteUint32( bhash, header.Blockdata.Height )
-		fmt.Printf( "DATA_BlockHash table key: %x\n",  bhash )
-
-		// generate value
-		hashwriter := bytes.NewBuffer(nil)
-		hashvalue := header.Blockdata.Hash()
-		hashvalue.Serialize(hashwriter)
-		fmt.Printf( "DATA_BlockHash table value: %x\n",  hashvalue )
-
-		// PUT VALUE
-		err = bd.Put( bhash.Bytes(), hashwriter.Bytes() )
-		if ( err != nil ){
-			return err
-		}
-
-		return nil
-	*/
 }
+*/
 
 func (bd *LevelDBStore) GetHeader(hash Uint256) (*Header, error) {
 	// TODO: GET HEADER
@@ -333,26 +323,9 @@ func (bd *LevelDBStore) GetAsset(hash Uint256) (*Asset, error) {
 	return asset, nil
 }
 
-/*
-func (bd *LevelDBStore) GetNextBlockHash(hash []byte) common.Uint256 {
-	h,_ := bd.GetHeader( hash )
-
-	if ( h == nil ) {
-		return nil
-	}
-
-	if ( h.Blockdata.Height + 1 >= uint32(len(*bd.header_index)) ) {
-		return nil
-	}
-
-	return (*bd.header_index)[h.Blockdata.Height + 1];
-}
-*/
-
 func (bd *LevelDBStore) GetTransaction(hash Uint256) (*tx.Transaction, error) {
-	log.Trace()
-	log.Debug(fmt.Sprintf("GetTransaction Hash: %x\n", hash))
-  
+	//Trace()
+	//log.Debug(fmt.Sprintf("GetTransaction Hash: %x\n", hash))
 	t := new(tx.Transaction)
 	err := bd.getTx(t, hash)
 
@@ -369,7 +342,7 @@ func (bd *LevelDBStore) getTx(tx *tx.Transaction, hash Uint256) error {
 	//log.Debug(fmt.Sprintf("getTx Data: %x\n", tHash))
 	if err_get != nil {
 		//TODO: implement error process
-		log.Warn("Get TX from DB error")
+		//log.Warn("Get TX from DB error")
 		return err_get
 	}
 
@@ -441,7 +414,7 @@ func (bd *LevelDBStore) GetBlock(hash Uint256) (*Block, error) {
 	//log.Debug(fmt.Sprintf("sysfee: %d\n", sysfee))
 
 	// Deserialize block data
-	err = b.Deserialize(r)
+	err = b.FromTrimmedData(r)
 	if err != nil {
 		return nil, err
 	}
@@ -475,7 +448,7 @@ func (bd *LevelDBStore) persist(b *Block) error {
 	w := bytes.NewBuffer(nil)
 	var sysfee uint64 = 0xFFFFFFFFFFFFFFFF
 	serialization.WriteUint64(w, sysfee)
-	b.Serialize(w)
+	b.Trim(w)
 
 	// BATCH PUT VALUE
 	batch.Put(bhhash.Bytes(), w.Bytes())
@@ -510,7 +483,7 @@ func (bd *LevelDBStore) persist(b *Block) error {
 	}*/
 
 	//////////////////////////////////////////////////////////////
-	// save transactions to leveldb
+	// save transcations to leveldb
 	nLen := len(b.Transactions)
 	for i := 0; i < nLen; i++ {
 		/*
@@ -530,7 +503,7 @@ func (bd *LevelDBStore) persist(b *Block) error {
 			}
 		}
 		if b.Transactions[i].TxType == tx.RegisterAsset {
-			ar := b.Transactions[i].Payload.(*payload.RegisterAsset)
+			ar := b.Transactions[i].Payload.(*payload.AssetRegistration)
 			err = bd.SaveAsset(b.Transactions[i].Hash(),ar.Asset)
 			if err != nil {
 				return err
@@ -635,6 +608,35 @@ func (bd *LevelDBStore) onAddHeader(header *Blockdata, batch *leveldb.Batch) {
 	batch.Put(currentheaderkey.Bytes(), currentheader.Bytes())
 }
 
+func (bd *LevelDBStore) persistBlocks(ledger *Ledger) {
+
+	bd.mutex.Lock()
+	defer bd.mutex.Unlock()
+
+	for !bd.disposed {
+		if uint32(len(bd.header_index)) <= bd.current_block_height+1 {
+			log.Warn("[persistBlocks]: warn, header_index.count < current_block_height + 1")
+			break
+		}
+
+		hash := bd.header_index[bd.current_block_height+1]
+
+		block, ok := bd.block_cache[hash]
+		if !ok {
+			log.Warn("[persistBlocks]: warn, block_cache not contain key hash.")
+			break
+		}
+		bd.persist(block)
+
+		// PersistCompleted event
+		ledger.Blockchain.BCEvents.Notify(events.EventBlockPersistCompleted, block)
+
+		delete(bd.block_cache, hash)
+	}
+
+}
+
+/*
 func (bd *LevelDBStore) persistBlocks() {
 	log.Debug("persistBlocks()")
 
@@ -653,7 +655,7 @@ func (bd *LevelDBStore) persistBlocks() {
 		//TODO: PersistCompleted
 	}
 }
-
+*/
 func (bd *LevelDBStore) SaveBlock(b *Block, ledger *Ledger) error {
 	log.Debug("SaveBlock()")
 
@@ -679,7 +681,7 @@ func (bd *LevelDBStore) SaveBlock(b *Block, ledger *Ledger) error {
 
 		batch := new(leveldb.Batch)
 		bd.onAddHeader(b.Blockdata, batch)
-		log.Debug("batch dump: ", batch.Dump())
+		//log.Debug("batch dump: ", batch.Dump())
 		err = bd.db.Write(batch, nil)
 		if err != nil {
 			return err
@@ -689,12 +691,11 @@ func (bd *LevelDBStore) SaveBlock(b *Block, ledger *Ledger) error {
 	}
 
 	if b.Blockdata.Height < uint32(len(bd.header_index)) {
-		// TODO: block event set
-		//new_block_event.Set();
-		bd.persistBlocks()
+		go bd.persistBlocks(ledger)
 	} else {
 		return errors.New("[SaveBlock] block height < header_index")
 	}
+
 
 	return nil
 }

--- a/core/store/LevelDBStore/LevelDBStore.go
+++ b/core/store/LevelDBStore/LevelDBStore.go
@@ -185,22 +185,22 @@ func (bd *LevelDBStore) GetContract(hash []byte) ([]byte, error) {
 	return bData, nil
 }
 
-func (bd *LevelDBStore) AddHeaders(headers []Blockdata, ledger *Ledger) error {
+func (bd *LevelDBStore) AddHeaders(headers []Header, ledger *Ledger) error {
 	bd.mutex.Lock()
 	defer bd.mutex.Unlock()
 
 	batch := new(leveldb.Batch)
 	for i:=0; i<len(headers); i++ {
-		if headers[i].Height-uint32(len(bd.header_index)) >= 1 {
+		if headers[i].Blockdata.Height-uint32(len(bd.header_index)) >= 1 {
 			break
 		}
 
-		if headers[i].Height < uint32(len(bd.header_index)) {
+		if headers[i].Blockdata.Height < uint32(len(bd.header_index)) {
 			continue
 		}
 
 		//header verify
-		err := validation.VerifyBlockData(&headers[i], ledger)
+		err := validation.VerifyHeader(&headers[i], ledger)
 		if err != nil {
 			break
 		}
@@ -324,8 +324,9 @@ func (bd *LevelDBStore) GetAsset(hash Uint256) (*Asset, error) {
 }
 
 func (bd *LevelDBStore) GetTransaction(hash Uint256) (*tx.Transaction, error) {
-	//Trace()
-	//log.Debug(fmt.Sprintf("GetTransaction Hash: %x\n", hash))
+	log.Trace()
+	log.Debug(fmt.Sprintf("GetTransaction Hash: %x\n", hash))
+
 	t := new(tx.Transaction)
 	err := bd.getTx(t, hash)
 
@@ -406,7 +407,7 @@ func (bd *LevelDBStore) GetBlock(hash Uint256) (*Block, error) {
 	r := bytes.NewReader(bHash)
 
 	// first 8 bytes is sys_fee
-	_,err := serialization.ReadUint64(r)
+	_, err := serialization.ReadUint64(r)
 	//sysfee, err := serialization.ReadUint64(r)
 	if err != nil {
 		return nil, err
@@ -453,10 +454,10 @@ func (bd *LevelDBStore) persist(b *Block) error {
 	// BATCH PUT VALUE
 	batch.Put(bhhash.Bytes(), w.Bytes())
 	/*
-	err := bd.Put(bhhash.Bytes(), w.Bytes())
-	if err != nil {
-		return err
-	}*/
+		err := bd.Put(bhhash.Bytes(), w.Bytes())
+		if err != nil {
+			return err
+		}*/
 
 	//////////////////////////////////////////////////////////////
 	// generate key with DATA_BlockHash prefix
@@ -477,13 +478,13 @@ func (bd *LevelDBStore) persist(b *Block) error {
 	// BATCH PUT VALUE
 	batch.Put(bhash.Bytes(), hashwriter.Bytes())
 	/*
-	err = bd.Put(bhash.Bytes(), hashwriter.Bytes())
-	if err != nil {
-		return err
-	}*/
+		err = bd.Put(bhash.Bytes(), hashwriter.Bytes())
+		if err != nil {
+			return err
+		}*/
 
 	//////////////////////////////////////////////////////////////
-	// save transcations to leveldb
+	// save transactions to leveldb
 	nLen := len(b.Transactions)
 	for i := 0; i < nLen; i++ {
 		/*
@@ -503,8 +504,8 @@ func (bd *LevelDBStore) persist(b *Block) error {
 			}
 		}
 		if b.Transactions[i].TxType == tx.RegisterAsset {
-			ar := b.Transactions[i].Payload.(*payload.AssetRegistration)
-			err = bd.SaveAsset(b.Transactions[i].Hash(),ar.Asset)
+			ar := b.Transactions[i].Payload.(*payload.RegisterAsset)
+			err = bd.SaveAsset(b.Transactions[i].Hash(), ar.Asset)
 			if err != nil {
 				return err
 			}
@@ -526,10 +527,10 @@ func (bd *LevelDBStore) persist(b *Block) error {
 	// BATCH PUT VALUE
 	batch.Put(currentblockkey.Bytes(), currentblock.Bytes())
 	/*
-	err = bd.Put(currentblockkey.Bytes(), currentblock.Bytes())
-	if err != nil {
-		return err
-	}*/
+		err = bd.Put(currentblockkey.Bytes(), currentblock.Bytes())
+		if err != nil {
+			return err
+		}*/
 
 	//bh := b.Blockdata.Hash()
 	//bd.header_index[bd.current_block_height] = &bh
@@ -542,12 +543,12 @@ func (bd *LevelDBStore) persist(b *Block) error {
 	return nil
 }
 
-func (bd *LevelDBStore) onAddHeader(header *Blockdata, batch *leveldb.Batch) {
-	log.Debug(fmt.Sprintf("onAddHeader(), Height=%d\n", header.Height))
+func (bd *LevelDBStore) onAddHeader(header *Header, batch *leveldb.Batch) {
+	log.Debug(fmt.Sprintf("onAddHeader(), Height=%d\n", header.Blockdata.Height))
 
-	hash := header.Hash()
-	bd.header_index[header.Height] = hash
-	for header.Height-bd.stored_header_count >= 2000 {
+	hash := header.Blockdata.Hash()
+	bd.header_index[header.Blockdata.Height] = hash
+	for header.Blockdata.Height-bd.stored_header_count >= 2000 {
 		hashbuffer := new(bytes.Buffer)
 		serialization.WriteVarUint(hashbuffer, uint64(2000))
 		var hasharray []byte
@@ -579,13 +580,15 @@ func (bd *LevelDBStore) onAddHeader(header *Blockdata, batch *leveldb.Batch) {
 	// add header prefix.
 	headerkey.WriteByte(byte(DATA_Header))
 	// contact block hash
-	blockhash := header.Hash()
+	blockhash := header.Blockdata.Hash()
 	blockhash.Serialize(headerkey)
 	log.Debug(fmt.Sprintf("header key: %x\n", headerkey))
 	//fmt.Println( "header key:",  headerkey.Bytes() )
 
 	// generate value
 	w := bytes.NewBuffer(nil)
+	var sysfee uint64 = 0xFFFFFFFFFFFFFFFF
+	serialization.WriteUint64(w, sysfee)
 	header.Serialize(w)
 	log.Debug(fmt.Sprintf("header data: %x\n", w))
 	//fmt.Println( "header data:",  w.Bytes() )
@@ -601,7 +604,7 @@ func (bd *LevelDBStore) onAddHeader(header *Blockdata, batch *leveldb.Batch) {
 
 	currentheader := bytes.NewBuffer(nil)
 	blockhash.Serialize(currentheader)
-	serialization.WriteUint32(currentheader, header.Height)
+	serialization.WriteUint32(currentheader, header.Blockdata.Height)
 	//fmt.Printf( "SYS_CurrentHeader data: %x\n",  currentheader )
 
 	// PUT VALUE
@@ -640,7 +643,7 @@ func (bd *LevelDBStore) persistBlocks(ledger *Ledger) {
 func (bd *LevelDBStore) persistBlocks() {
 	log.Debug("persistBlocks()")
 
-	if uint32(len(bd.header_index)) <= bd.current_block_height+1 {
+	if uint32(len(bd.header_index)) < bd.current_block_height+1 {
 		fmt.Printf("[persistBlocks]: error, header_index.count < current_block_height + 1")
 		return
 	}
@@ -666,6 +669,7 @@ func (bd *LevelDBStore) SaveBlock(b *Block, ledger *Ledger) error {
 		bd.block_cache[b.Hash()] = b
 	}
 
+	log.Info("len(bd.header_index) is ", len(bd.header_index), " ,b.Blockdata.Height is ", b.Blockdata.Height)
 	if b.Blockdata.Height-uint32(len(bd.header_index)) >= 1 {
 		//return false,NewDetailErr(errors.New(fmt.Sprintf("WARNING: [SaveBlock] block height - header_index.count >= 1, block height:%d, header_index.count:%d",b.Blockdata.Height, uint32(len(bd.header_index)) )),ErrDuplicatedBlock,"")
 		return errors.New(fmt.Sprintf("WARNING: [SaveBlock] block height - header_index.count >= 1, block height:%d, header_index.count:%d", b.Blockdata.Height, uint32(len(bd.header_index))))
@@ -680,7 +684,9 @@ func (bd *LevelDBStore) SaveBlock(b *Block, ledger *Ledger) error {
 		}
 
 		batch := new(leveldb.Batch)
-		bd.onAddHeader(b.Blockdata, batch)
+		h := new(Header)
+		h.Blockdata = b.Blockdata
+		bd.onAddHeader(h, batch)
 		//log.Debug("batch dump: ", batch.Dump())
 		err = bd.db.Write(batch, nil)
 		if err != nil {
@@ -701,5 +707,5 @@ func (bd *LevelDBStore) SaveBlock(b *Block, ledger *Ledger) error {
 }
 
 func (bd *LevelDBStore) GetQuantityIssued(AssetId Uint256) (*Fixed64, error) {
-	return nil,nil
+	return nil, nil
 }

--- a/core/validation/blockValidator.go
+++ b/core/validation/blockValidator.go
@@ -65,6 +65,10 @@ func VerifyBlock(block *ledger.Block, ld *ledger.Ledger, completely bool) error 
 	return nil
 }
 
+func VerifyHeader(bd *ledger.Header, ledger *ledger.Ledger) error {
+	return VerifyBlockData( bd.Blockdata, ledger )
+}
+
 func VerifyBlockData(bd *ledger.Blockdata, ledger *ledger.Ledger) error {
 	if bd.Height == 0 {
 		return nil

--- a/net/message/blockHdr.go
+++ b/net/message/blockHdr.go
@@ -131,17 +131,16 @@ func (msg headersReq) Handle(node Noder) error {
 
 func (msg blkHeader) Handle(node Noder) error {
 	log.Trace()
-	for i := 0; i < int(msg.cnt); i++ {
-		var header ledger.Header
-		header.Blockdata = &msg.blkHdr[i]
-		err := ledger.DefaultLedger.Store.SaveHeader(&header, ledger.DefaultLedger)
-		if err != nil {
-			log.Warn("Add block Header error")
-			return errors.New("Add block Header error\n")
-		}
+
+	err := ledger.DefaultLedger.Store.AddHeaders(msg.blkHdr, ledger.DefaultLedger)
+	if err != nil {
+		log.Warn("Add block Header error")
+		return errors.New("Add block Header error\n")
 	}
+
 	return nil
 }
+
 func GetHeadersFromHash(starthash common.Uint256, stophash common.Uint256) ([]ledger.Blockdata, uint32, error) {
 	var count uint32 = 0
 	var empty [HASHLEN]byte


### PR DESCRIPTION
when headers sync to local, save headers to leveldb in batch.
when blocks sync to local, save it in cache first, then persist block to leveldb while height of blocks is in order at cache.

Signed-off-by: zhengq1 <ljqlyy@gmail.com>