### PR TITLE
Txnpool(transaction pool) clear bug

### DIFF
--- a/consensus/dbft/dbftService.go
+++ b/consensus/dbft/dbftService.go
@@ -125,6 +125,16 @@ func (ds *DbftService) BlockPersistCompleted(v interface{}) {
 	log.Trace()
 	if block, ok := v.(*ledger.Block); ok {
 		log.Info(fmt.Sprintf("persist block: %d", block.Hash()))
+		//TODO: workarround start
+		var trxHashToBeDelete []*Uint256
+		for _, transaction := range block.Transactions {
+			temp := *transaction
+			hash := temp.Hash()
+			trxHashToBeDelete = append(trxHashToBeDelete,&hash)
+		}
+		ds.localNet.CleanTxnPool(trxHashToBeDelete)
+		//TODO: workarround end
+		log.Fatal(fmt.Sprintf("persist block: %d with %d transactions\n", block.Hash(),len(trxHashToBeDelete)))
 	}
 
 	ds.blockReceivedTime = time.Now()
@@ -430,7 +440,7 @@ func (ds *DbftService) PrepareRequestReceived(payload *msg.ConsensusPayload, mes
 	ds.context.Signatures = make([][]byte, len(ds.context.Miners))
 	ds.context.Signatures[payload.MinerIndex] = message.Signature
 
-	mempool := ds.localNet.GetTxnPool(true)
+	mempool := ds.localNet.GetTxnPool(false)
 	for _, hash := range ds.context.TransactionHashes[1:] {
 		if transaction, ok := mempool[hash]; ok {
 			if err := ds.AddTransaction(transaction, false); err != nil {
@@ -573,7 +583,7 @@ func (ds *DbftService) Timeout() {
 			}
 
 			ds.context.Nonce = GetNonce()
-			transactionsPool := ds.localNet.GetTxnPool(true) //TODO: add policy
+			transactionsPool := ds.localNet.GetTxnPool(false) //TODO: add policy
 
 			//TODO: add max TX limitation
 

--- a/consensus/dbft/dbftService.go
+++ b/consensus/dbft/dbftService.go
@@ -125,7 +125,6 @@ func (ds *DbftService) BlockPersistCompleted(v interface{}) {
 	log.Trace()
 	if block, ok := v.(*ledger.Block); ok {
 		log.Info(fmt.Sprintf("persist block: %d", block.Hash()))
-		//TODO: workarround start
 		var trxHashToBeDelete []*Uint256
 		for _, transaction := range block.Transactions {
 			temp := *transaction
@@ -133,8 +132,7 @@ func (ds *DbftService) BlockPersistCompleted(v interface{}) {
 			trxHashToBeDelete = append(trxHashToBeDelete,&hash)
 		}
 		ds.localNet.CleanTxnPool(trxHashToBeDelete)
-		//TODO: workarround end
-		log.Fatal(fmt.Sprintf("persist block: %d with %d transactions\n", block.Hash(),len(trxHashToBeDelete)))
+		//log.Debug(fmt.Sprintf("persist block: %d with %d transactions\n", block.Hash(),len(trxHashToBeDelete)))
 	}
 
 	ds.blockReceivedTime = time.Now()

--- a/net/net.go
+++ b/net/net.go
@@ -16,6 +16,8 @@ type Neter interface {
 	Xmit(common.Inventory) error // The transmit interface
 	GetEvent(eventName string) *events.Event
 	GetMinersAddrs() ([]*crypto.PubKey, uint64)
+	CleanTxnPool(txHashes []*common.Uint256) error
+
 }
 
 func StartProtocol(pubKey *crypto.PubKey) (Neter, protocol.Noder) {

--- a/net/node/transactionPool.go
+++ b/net/node/transactionPool.go
@@ -71,12 +71,12 @@ func (txnPool *TXNPool) CleanTxnPool(txHashes []*common.Uint256) error{
 		if _,ok:= txnPool.list[*txHash]; ok{
 			delete(txnPool.list,*txHash)
 			cleaned ++
-		}else{
-			log.Fatal("Delete failed of transaction hash =",txHash)
 		}
 	}
-
-	log.Fatal(fmt.Sprintf("[CleanTxnPool], Requested %d clean, %d transactions cleaned from localNode.TransPool and remains %d still in TxPool",txsNum,cleaned,txInPoolNum-cleaned))
+	if len(txHashes) - cleaned != 1{
+		log.Fatal(fmt.Sprintf("The Transactions num Unmatched. Expect %d, got %d .\n",len(txHashes),cleaned))
+	}
+	log.Debug(fmt.Sprintf("[CleanTxnPool], Requested %d clean, %d transactions cleaned from localNode.TransPool and remains %d still in TxPool",txsNum,cleaned,txInPoolNum-cleaned))
 	return nil
 }
 

--- a/net/node/transactionPool.go
+++ b/net/node/transactionPool.go
@@ -2,10 +2,12 @@ package node
 
 import (
 	"DNA/common"
+	"DNA/common/log"
 	"DNA/core/transaction"
 	msg "DNA/net/message"
 	. "DNA/net/protocol"
 	"sync"
+	"fmt"
 )
 
 type TXNPool struct {
@@ -46,7 +48,36 @@ func (txnPool *TXNPool) GetTxnPool(cleanPool bool) map[common.Uint256]*transacti
 	if cleanPool == true {
 		txnPool.init()
 	}
-	return list
+	return DeepCopy(list)
+}
+
+func DeepCopy(mapIn map[common.Uint256]*transaction.Transaction) map[common.Uint256]*transaction.Transaction {
+	reply := make( map[common.Uint256]*transaction.Transaction)
+	for k, v := range mapIn {
+		reply[k] =v
+	}
+	return reply
+}
+
+// Attention: clean the trasaction Pool with committed transactions.
+func (txnPool *TXNPool) CleanTxnPool(txHashes []*common.Uint256) error{
+	txnPool.Lock()
+	defer txnPool.Unlock()
+
+	txsNum := len(txHashes)
+	txInPoolNum := len(txnPool.list)
+	cleaned :=0
+	for _, txHash := range txHashes {
+		if _,ok:= txnPool.list[*txHash]; ok{
+			delete(txnPool.list,*txHash)
+			cleaned ++
+		}else{
+			log.Fatal("Delete failed of transaction hash =",txHash)
+		}
+	}
+
+	log.Fatal(fmt.Sprintf("[CleanTxnPool], Requested %d clean, %d transactions cleaned from localNode.TransPool and remains %d still in TxPool",txsNum,cleaned,txInPoolNum-cleaned))
+	return nil
 }
 
 func (txnPool *TXNPool) init() {

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -65,6 +65,7 @@ type Noder interface {
 	GetHeight() uint64
 	GetConnectionCnt() uint
 	GetTxnPool(bool) map[common.Uint256]*transaction.Transaction
+	CleanTxnPool(txHashes []*common.Uint256) error
 	AppendTxnPool(*transaction.Transaction) bool
 	ExistedID(id common.Uint256) bool
 	ReqNeighborList()


### PR DESCRIPTION
Fixed the transaction pool clear issue.

There occurs some transaction lost in this version, the problem is due to the transaction pool clean up rules.
So i Submitted the following amendments, the test result seems ok.

dbftService.go
   add clean func when BlockPersistCompleted.  only need to clear the committed transactions.
transactionPool.go
   CleanTxnPool> delete the Specified transactions from transactionPool.
   DeepCopy> retun the value copyed map to solve the map use conflict with other goroutin.
protocol.go
   add CleanTxnPool to interface.
net.go
   add CleanTxnPool to interface.