### PR TITLE
Fix vm verify multi signature bug

### DIFF
--- a/vm/func_crypto.go
+++ b/vm/func_crypto.go
@@ -62,7 +62,7 @@ func opCheckMultiSig(e *ExecutionEngine) (VMState, error) {
 	}
 
 	signatures := make([][]byte, m)
-	for i := 0; i < n; i++ {
+	for i := 0; i < m; i++ {
 		signatures[i] = AssertStackItem(e.evaluationStack.Pop()).GetByteArray()
 	}
 
@@ -70,10 +70,7 @@ func opCheckMultiSig(e *ExecutionEngine) (VMState, error) {
 	fSuccess := true
 
 	for i, j := 0, 0; fSuccess && i < m && j < n; {
-		ver, err := e.crypto.VerifySignature(message, signatures[i], pubkeys[j])
-		if err != nil {
-			return FAULT, err
-		}
+		ver, _ := e.crypto.VerifySignature(message, signatures[i], pubkeys[j])
 		if ver {
 			i++
 		}


### PR DESCRIPTION
1.When get signature list from vm stack, should use the signature list length for the loop. (there is a mistake in previous code). 
2.Verify the signature failure doesn't need to return verify fail, it is unnecessary verify all successful.