### PR TITLE
Some performance issue fix.

### DIFF
--- a/consensus/dbft/dbftService.go
+++ b/consensus/dbft/dbftService.go
@@ -134,6 +134,9 @@ func (ds *DbftService) BlockPersistCompleted(v interface{}) {
 
 func (ds *DbftService) CheckExpectedView(viewNumber byte) {
 	log.Trace()
+	if ds.context.State.HasFlag(BlockSent){
+		return
+	}
 	if ds.context.ViewNumber == viewNumber {
 		return
 	}

--- a/core/validation/blockValidator.go
+++ b/core/validation/blockValidator.go
@@ -18,9 +18,7 @@ func VerifyBlock(block *ledger.Block, ld *ledger.Ledger, completely bool) error 
 	}
 
 	flag, err := VerifySignableData(block)
-	if flag && err == nil {
-		return nil
-	} else {
+	if flag == false || err != nil {
 		return err
 	}
 
@@ -38,23 +36,20 @@ func VerifyBlock(block *ledger.Block, ld *ledger.Ledger, completely bool) error 
 
 	//verfiy block's transactions
 	if completely {
-	/*
-		mineraddress, err := ledger.GetMinerAddress(ld.Blockchain.GetMinersByTXs(block.Transactions))
-		if err != nil {
-			return errors.New(fmt.Sprintf("GetMinerAddress Failed."))
-		}
-		if block.Blockdata.NextMiner != mineraddress {
-			return errors.New(fmt.Sprintf("Miner is not validate."))
-		}
-	*/
-		//TODO: NextMiner Check.
-		for _, txVerify := range block.Transactions {
-			transpool := []*tx.Transaction{}
-			for _, tx := range block.Transactions {
-				if tx.Hash() != txVerify.Hash() {
-					transpool = append(transpool, tx)
-				}
+		/*
+			mineraddress, err := ledger.GetMinerAddress(ld.Blockchain.GetMinersByTXs(block.Transactions))
+			if err != nil {
+				return errors.New(fmt.Sprintf("GetMinerAddress Failed."))
 			}
+			if block.Blockdata.NextMiner != mineraddress {
+				return errors.New(fmt.Sprintf("Miner is not validate."))
+			}
+		*/
+		//TODO: NextMiner Check.
+		for num, txVerify := range block.Transactions {
+			transpool := []*tx.Transaction{}
+			transpool = append(transpool, block.Transactions[:num]...)
+			transpool = append(transpool, block.Transactions[num+1:]...)
 			err := VerifyTransaction(txVerify, ld, transpool)
 			if err != nil {
 				return errors.New(fmt.Sprintf("The Input is exist in serval transaction in one block."))
@@ -66,7 +61,7 @@ func VerifyBlock(block *ledger.Block, ld *ledger.Ledger, completely bool) error 
 }
 
 func VerifyHeader(bd *ledger.Header, ledger *ledger.Ledger) error {
-	return VerifyBlockData( bd.Blockdata, ledger )
+	return VerifyBlockData(bd.Blockdata, ledger)
 }
 
 func VerifyBlockData(bd *ledger.Blockdata, ledger *ledger.Ledger) error {

--- a/core/validation/txValidator.go
+++ b/core/validation/txValidator.go
@@ -1,12 +1,12 @@
 package validation
 
 import (
+	"DNA/common"
 	"DNA/core/ledger"
 	tx "DNA/core/transaction"
+	"DNA/core/transaction/payload"
 	"errors"
 	"math"
-	"DNA/core/transaction/payload"
-	"DNA/common"
 )
 
 //Verfiy the transcation for following points
@@ -17,30 +17,43 @@ import (
 func VerifyTransaction(Tx *tx.Transaction, ledger *ledger.Ledger, TxPool []*tx.Transaction) error {
 
 	err := CheckDuplicateInput(Tx)
-	if(err != nil){return err}
-
-	err = IsDoubleSpend(Tx,ledger)
-	if(err != nil){return err}
-
-	if TxPool != nil{
-		err = CheckMemPool(Tx,TxPool)
-		if(err != nil){return err}
+	if err != nil {
+		return err
 	}
 
+	err = IsDoubleSpend(Tx, ledger)
+	if err != nil {
+		return err
+	}
+
+	if TxPool != nil {
+		err = CheckMemPool(Tx, TxPool)
+		if err != nil {
+			return err
+		}
+	}
 
 	err = CheckAssetPrecision(Tx)
-	if(err != nil){return err}
+	if err != nil {
+		return err
+	}
 
 	err = CheckTransactionBalance(Tx)
-	if(err != nil){return err}
+	if err != nil {
+		return err
+	}
 
 	err = CheckAttributeProgram(Tx)
-	if(err != nil){return err}
+	if err != nil {
+		return err
+	}
 
 	err = CheckTransactionContracts(Tx)
-	if(err != nil){return err}
+	if err != nil {
+		return err
+	}
 
-	if Tx.TxType == tx.IssueAsset{
+	if Tx.TxType == tx.IssueAsset {
 		results, err := Tx.GetTransactionResults()
 		if err != nil {
 			return errors.New("[VerifyTransaction], GetTransactionResults failed.")
@@ -48,22 +61,21 @@ func VerifyTransaction(Tx *tx.Transaction, ledger *ledger.Ledger, TxPool []*tx.T
 
 		for _, v := range results {
 			//Get the Asset amount when RegisterAsseted.
-			trx,err := tx.TxStore.GetTransaction(v.AssetId)
+			trx, err := tx.TxStore.GetTransaction(v.AssetId)
 			if err != nil {
 				return errors.New("[VerifyTransaction], AssetId does exist.")
 			}
-			if trx.TxType != tx.RegisterAsset{
+			if trx.TxType != tx.RegisterAsset {
 				return errors.New("[VerifyTransaction], TxType is illegal.")
 			}
 			AssetReg := trx.Payload.(*payload.RegisterAsset)
 
-
 			//Get the amount has been issued of this assetID
 			var quantity_issued *common.Fixed64
-			if AssetReg.Amount < common.Fixed64(0){
+			if AssetReg.Amount < common.Fixed64(0) {
 				continue
-			}else{
-				quantity_issued,err = tx.TxStore.GetQuantityIssued(v.AssetId)
+			} else {
+				quantity_issued, err = tx.TxStore.GetQuantityIssued(v.AssetId)
 				if err != nil {
 					return errors.New("[VerifyTransaction], GetQuantityIssued failed.")
 				}
@@ -71,10 +83,10 @@ func VerifyTransaction(Tx *tx.Transaction, ledger *ledger.Ledger, TxPool []*tx.T
 
 			//calc the amounts in txPool
 			var txPoolAmounts common.Fixed64
-			if TxPool != nil{
+			if TxPool != nil {
 				for _, t := range TxPool {
 					for _, outputs := range t.Outputs {
-						if outputs.AssetID == v.AssetId{
+						if outputs.AssetID == v.AssetId {
 							txPoolAmounts = txPoolAmounts + v.Amount
 						}
 					}
@@ -85,7 +97,7 @@ func VerifyTransaction(Tx *tx.Transaction, ledger *ledger.Ledger, TxPool []*tx.T
 			//AssetReg.Amount : amount when RegisterAsset of this assedID
 			//quantity_issued : amount has been issued of this assedID
 			//txPoolAmounts   : amount in transactionPool of this assedID
-			if AssetReg.Amount - *quantity_issued < - txPoolAmounts{
+			if AssetReg.Amount-*quantity_issued < -txPoolAmounts {
 				return errors.New("[VerifyTransaction], Amount check error.")
 			}
 
@@ -96,7 +108,9 @@ func VerifyTransaction(Tx *tx.Transaction, ledger *ledger.Ledger, TxPool []*tx.T
 }
 
 func CheckMemPool(tx *tx.Transaction, TxPool []*tx.Transaction) error {
-
+	if len(tx.UTXOInputs) == 0 {
+		return nil
+	}
 	for _, poolTx := range TxPool {
 		for _, poolInput := range poolTx.UTXOInputs {
 			for _, txInput := range tx.UTXOInputs {
@@ -110,6 +124,9 @@ func CheckMemPool(tx *tx.Transaction, TxPool []*tx.Transaction) error {
 }
 
 func CheckDuplicateInput(tx *tx.Transaction) error {
+	if len(tx.UTXOInputs) == 0 {
+		return nil
+	}
 	for i, utxoin := range tx.UTXOInputs {
 		for j := 0; j < i; j++ {
 			if utxoin.ReferTxID == tx.UTXOInputs[j].ReferTxID && utxoin.ReferTxOutputIndex == tx.UTXOInputs[j].ReferTxOutputIndex {
@@ -126,8 +143,8 @@ func IsDoubleSpend(tx *tx.Transaction, ledger *ledger.Ledger) error {
 
 func CheckAssetPrecision(Tx *tx.Transaction) error {
 	for k, outputs := range Tx.AssetOutputs {
-		asset,err:= ledger.DefaultLedger.GetAsset(k)
-		if err!= nil{
+		asset, err := ledger.DefaultLedger.GetAsset(k)
+		if err != nil {
 			return errors.New("The asset not exist in local blockchain.")
 		}
 		precision := asset.Precision
@@ -141,14 +158,13 @@ func CheckAssetPrecision(Tx *tx.Transaction) error {
 }
 
 func CheckTransactionBalance(Tx *tx.Transaction) error {
-	if (len(Tx.AssetInputAmount) != len(Tx.AssetOutputAmount)){
-		return  errors.New("The number of asset is not same between inputs and outputs.")
+	if len(Tx.AssetInputAmount) != len(Tx.AssetOutputAmount) {
+		return errors.New("The number of asset is not same between inputs and outputs.")
 	}
 
-
-	for k, v := range Tx.AssetInputAmount{
-		if(v != Tx.AssetOutputAmount[k]){
-			return  errors.New("The amount of asset is not same between inputs and outputs.")
+	for k, v := range Tx.AssetInputAmount {
+		if v != Tx.AssetOutputAmount[k] {
+			return errors.New("The amount of asset is not same between inputs and outputs.")
 		}
 	}
 	return nil
@@ -160,8 +176,8 @@ func CheckAttributeProgram(Tx *tx.Transaction) error {
 }
 
 func CheckTransactionContracts(Tx *tx.Transaction) error {
-	flag,err := VerifySignableData(Tx)
-	if ( flag && err == nil ) {
+	flag, err := VerifySignableData(Tx)
+	if flag && err == nil {
 		return nil
 	} else {
 		return err


### PR DESCRIPTION
Some performance issue fix.

<dbftService.go>
1.When in BlockSent status, should not changeView, just need to wait the block persistent complete.
<blockValidator.go>
1.append has a large performance loss,so changed to only 2 append process.
2.should not return when  VerifySignableData ok, otherwise it will skip the transaction verify.
<txValidator.go>
1.With no UTXOInputs could return it immediately. otherwise, it will run len([]*tx.Transaction) times.

Signed-off-by: luodanwg<luodan.wg@gmail.com>
