### PR TITLE
Change the inv message content

### DIFF
--- a/core/ledger/header.go
+++ b/core/ledger/header.go
@@ -16,8 +16,9 @@ func (h *Header) Serialize(w io.Writer) {
 }
 
 func (h *Header) Deserialize(r io.Reader) error {
-	h.Blockdata.Deserialize(r)
-
+	header := new(Blockdata)
+	header.Deserialize(r)
+	h.Blockdata = header
 	var headerFlag [1]byte
 	_, err := io.ReadFull(r, headerFlag[:])
 	if err != nil {

--- a/net/message/block.go
+++ b/net/message/block.go
@@ -45,11 +45,11 @@ func (msg dataReq) Handle(node Noder) error {
 	switch reqtype {
 	case common.BLOCK:
 		block, err := NewBlockFromHash(hash)
-		log.Debug("block height is ", block.Blockdata.Height, " ,block hash is ", block.Hash())
 		if err != nil {
 			log.Error("Can't get block from hash: ", hash)
 			return err
 		}
+		log.Debug("block height is ", block.Blockdata.Height, " ,hash is ", hash)
 		buf, err := NewBlock(block)
 		if err != nil {
 			return err


### PR DESCRIPTION
Add cnt in invPayload to record the hash count, so that the
serialize doesn't need to calculate the length and save it
in front of the serialized hash. Also the deserialize doesn't
need to judge the length itself.

Signed-off-by: Jin Qing <1091147665@qq.com>