### PR TITLE
solve the transaction missing issue.

### DIFF
--- a/core/validation/blockValidator.go
+++ b/core/validation/blockValidator.go
@@ -48,8 +48,7 @@ func VerifyBlock(block *ledger.Block, ld *ledger.Ledger, completely bool) error 
 		//TODO: NextMiner Check.
 		for num, txVerify := range block.Transactions {
 			transpool := []*tx.Transaction{}
-			transpool = append(transpool, block.Transactions[:num]...)
-			transpool = append(transpool, block.Transactions[num+1:]...)
+			transpool = append(block.Transactions[:num], block.Transactions[num+1:]...)
 			err := VerifyTransaction(txVerify, ld, transpool)
 			if err != nil {
 				return errors.New(fmt.Sprintf("The Input is exist in serval transaction in one block."))

--- a/net/net.go
+++ b/net/net.go
@@ -3,6 +3,7 @@ package net
 import (
 	"DNA/common"
 	"DNA/config"
+	"DNA/core/ledger"
 	"DNA/core/transaction"
 	"DNA/crypto"
 	"DNA/events"
@@ -16,6 +17,7 @@ type Neter interface {
 	Xmit(common.Inventory) error // The transmit interface
 	GetEvent(eventName string) *events.Event
 	GetMinersAddrs() ([]*crypto.PubKey, uint64)
+	CleanSubmittedTransactions(block *ledger.Block) error
 }
 
 func StartProtocol(pubKey *crypto.PubKey) (Neter, protocol.Noder) {

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"DNA/common"
+	"DNA/core/ledger"
 	"DNA/core/transaction"
 	"DNA/crypto"
 	"DNA/events"
@@ -89,6 +90,7 @@ type Noder interface {
 	SetMinerAddr(pk *crypto.PubKey)
 	GetNeighborHeights() ([]uint64, uint64)
 	SyncNodeHeight()
+	CleanSubmittedTransactions(block *ledger.Block) error
 }
 
 type JsonNoder interface {


### PR DESCRIPTION
make TXNPool to clear after blockPersistent.

solved the transaction missing issue.
Changed TxnPool to clean after block persist completed.
Delete more than 4000 transactions spend about 20-30ms in 
normal PC testing 

Signed-off-by: junjie luodan.wg@gmail.com