### PR TITLE
bug fixes for nodectl, httpjson, and tx

### DIFF
--- a/common/log/log.go
+++ b/common/log/log.go
@@ -102,7 +102,7 @@ func New(out io.Writer, prefix string, flag, level int) *Logger {
 func (l *Logger) SetDebugLevel(level int) error {
 	l.Lock()
 	defer l.Unlock()
-	if level >= maxLevelLog || level < 0 {
+	if level > maxLevelLog || level < 0 {
 		return errors.New("Invalid Debug Level")
 	}
 	l.level = level

--- a/core/validation/txValidator.go
+++ b/core/validation/txValidator.go
@@ -97,10 +97,14 @@ func VerifyTransaction(Tx *tx.Transaction, ledger *ledger.Ledger, TxPool []*tx.T
 			//AssetReg.Amount : amount when RegisterAsset of this assedID
 			//quantity_issued : amount has been issued of this assedID
 			//txPoolAmounts   : amount in transactionPool of this assedID
-			if AssetReg.Amount-*quantity_issued < -txPoolAmounts {
-				return errors.New("[VerifyTransaction], Amount check error.")
-			}
 
+			// TODO: check this after the function TxStore.GetQuantityIssued works
+			_ = quantity_issued
+			/*
+				if AssetReg.Amount-*quantity_issued < -txPoolAmounts {
+					return errors.New("[VerifyTransaction], Amount check error.")
+				}
+			*/
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func OpenClientAndGetAccount() Client {
 	if fileExisted("wallet.txt") {
 		c = OpenClient("wallet.txt", []byte("\x12\x34\x56"))
 	} else {
-		c4 = CreateClient("wallet.txt", []byte("\x12\x34\x56"))
+		c = CreateClient("wallet.txt", []byte("\x12\x34\x56"))
 	}
 
 	switch clientName {

--- a/net/httpjsonrpc/common.go
+++ b/net/httpjsonrpc/common.go
@@ -1,21 +1,21 @@
 package httpjsonrpc
 
 import (
-	"DNA/consensus/dbft"
 	. "DNA/common"
+	"DNA/consensus/dbft"
 	. "DNA/core/transaction"
 	tx "DNA/core/transaction"
 	. "DNA/net/protocol"
 	"encoding/json"
 	"io/ioutil"
-	"sync"
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 )
 
 func init() {
-	mainMux.m = make(map[string]func(*http.Request, map[string]interface{}) map[string]interface{})
+	mainMux.m = make(map[string]func(map[string]interface{}) map[string]interface{})
 }
 
 //an instance of the multiplexer
@@ -26,7 +26,7 @@ var dBFT *dbft.DbftService
 //multiplexer that keeps track of every function to be called on specific rpc call
 type ServeMux struct {
 	sync.RWMutex
-	m               map[string]func(*http.Request, map[string]interface{}) map[string]interface{}
+	m               map[string]func(map[string]interface{}) map[string]interface{}
 	defaultFunction func(http.ResponseWriter, *http.Request)
 }
 
@@ -59,12 +59,12 @@ type TxoutputMap struct {
 }
 
 type AmountMap struct {
-	Key Uint256
+	Key   Uint256
 	Value Fixed64
 }
 
 type ProgramInfo struct {
-	Code string
+	Code      string
 	Parameter string
 }
 
@@ -82,8 +82,8 @@ type Transactions struct {
 	AssetOutputs      []TxoutputMap
 	AssetInputAmount  []AmountMap
 	AssetOutputAmount []AmountMap
-	
-	Hash  string
+
+	Hash string
 }
 
 type BlockHead struct {
@@ -95,8 +95,8 @@ type BlockHead struct {
 	ConsensusData    uint64
 	NextMiner        string
 	Program          ProgramInfo
-	
-	Hash             string
+
+	Hash string
 }
 
 type BlockInfo struct {
@@ -126,8 +126,8 @@ type NodeInfo struct {
 	Services uint64 // The services the node supplied
 	Relay    bool   // The relay capability of the node (merge into capbility flag)
 	Height   uint64 // The node latest block height
-	TxnCnt	  uint64 // The transactions be transmit by this node
-	RxTxnCnt  uint64 // The transaction received by this node
+	TxnCnt   uint64 // The transactions be transmit by this node
+	RxTxnCnt uint64 // The transaction received by this node
 }
 
 type ConsensusInfo struct {
@@ -147,7 +147,7 @@ func RegistDbftService(d *dbft.DbftService) {
 }
 
 //a function to register functions to be called for specific rpc calls
-func HandleFunc(pattern string, handler func(*http.Request, map[string]interface{}) map[string]interface{}) {
+func HandleFunc(pattern string, handler func(map[string]interface{}) map[string]interface{}) {
 	mainMux.Lock()
 	defer mainMux.Unlock()
 	mainMux.m[pattern] = handler
@@ -208,7 +208,7 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 	function, ok := mainMux.m[request["method"].(string)]
 
 	if ok {
-		response := function(r, request)
+		response := function(request)
 		//response from the program is encoded
 		data, err := json.Marshal(response)
 		if err != nil {

--- a/net/httpjsonrpc/interfaces.go
+++ b/net/httpjsonrpc/interfaces.go
@@ -10,7 +10,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"net/http"
 )
 
 func TransArryByteToHexString(ptx *tx.Transaction) *Transactions {
@@ -63,7 +62,7 @@ func TransArryByteToHexString(ptx *tx.Transaction) *Transactions {
 		trans.Programs[n].Parameter = ToHexString(v.Parameter)
 		n++
 	}
-	
+
 	n = 0
 	trans.AssetOutputs = make([]TxoutputMap, len(ptx.AssetOutputs))
 	for k, v := range ptx.AssetOutputs {
@@ -99,14 +98,14 @@ func TransArryByteToHexString(ptx *tx.Transaction) *Transactions {
 	return trans
 }
 
-func getBestBlockHash(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func getBestBlockHash(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	hash := ledger.DefaultLedger.Blockchain.CurrentBlockHash()
 	response := responsePacking(ToHexString(hash.ToArray()), id)
 	return response
 }
 
-func getBlock(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func getBlock(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	params := cmd["params"]
 	var err error
@@ -157,13 +156,13 @@ func getBlock(req *http.Request, cmd map[string]interface{}) map[string]interfac
 	return responsePacking(b, id)
 }
 
-func getBlockCount(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func getBlockCount(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	count := ledger.DefaultLedger.Blockchain.BlockHeight + 1
 	return responsePacking(count, id)
 }
 
-func getBlockHash(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func getBlockHash(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	index := cmd["params"]
 	var hash Uint256
@@ -175,7 +174,7 @@ func getBlockHash(req *http.Request, cmd map[string]interface{}) map[string]inte
 	return responsePacking(hashhex, id)
 }
 
-func getTxn(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func getTxn(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	params := cmd["params"]
 	var hash Uint256
@@ -193,23 +192,23 @@ func getTxn(req *http.Request, cmd map[string]interface{}) map[string]interface{
 	return responsePacking(tran, id)
 }
 
-func getAddrTxn(req *http.Request, cnd map[string]interface{}) map[string]interface{} {
+func getAddrTxn(cmd map[string]interface{}) map[string]interface{} {
 	return nil
 }
 
-func getConnectionCount(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func getConnectionCount(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	count := node.GetConnectionCnt()
 	return responsePacking(count, id)
 }
 
-func getRawMemPool(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func getRawMemPool(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	mempoollist := node.GetTxnPool(false)
 	return responsePacking(mempoollist, id)
 }
 
-func getRawTransaction(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func getRawTransaction(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	params := cmd["params"]
 	txid := params.([]interface{})[0].(string)
@@ -234,7 +233,7 @@ func getRawTransaction(req *http.Request, cmd map[string]interface{}) map[string
 	return responsePacking(txBuffer.Bytes(), id)
 }
 
-func getTxout(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func getTxout(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	//params := cmd["params"]
 	//txid := params.([]interface{})[0].(string)
@@ -250,7 +249,7 @@ func getTxout(req *http.Request, cmd map[string]interface{}) map[string]interfac
 	return responsePacking(to, id)
 }
 
-func sendRawTransaction(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func sendRawTransaction(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	hexValue := cmd["params"].(string)
 	hexSlice, _ := hex.DecodeString(hexValue)
@@ -260,7 +259,7 @@ func sendRawTransaction(req *http.Request, cmd map[string]interface{}) map[strin
 	return responsePacking(err, id)
 }
 
-func submitBlock(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func submitBlock(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	hexValue := cmd["params"].(string)
 	hexSlice, _ := hex.DecodeString(hexValue)
@@ -271,13 +270,13 @@ func submitBlock(req *http.Request, cmd map[string]interface{}) map[string]inter
 	return response
 }
 
-func getNeighbor(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func getNeighbor(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	addr, _ := node.GetNeighborAddrs()
 	return responsePacking(addr, id)
 }
 
-func getNodeState(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func getNodeState(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	n := NodeInfo{
 		State:    uint(node.GetState()),
@@ -294,7 +293,7 @@ func getNodeState(req *http.Request, cmd map[string]interface{}) map[string]inte
 	return responsePacking(n, id)
 }
 
-func startConsensus(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func startConsensus(cmd map[string]interface{}) map[string]interface{} {
 	var response map[string]interface{}
 	id := cmd["id"]
 	err := dBFT.Start()
@@ -306,7 +305,7 @@ func startConsensus(req *http.Request, cmd map[string]interface{}) map[string]in
 	return response
 }
 
-func stopConsensus(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func stopConsensus(cmd map[string]interface{}) map[string]interface{} {
 	var response map[string]interface{}
 	id := cmd["id"]
 	err := dBFT.Halt()
@@ -318,7 +317,7 @@ func stopConsensus(req *http.Request, cmd map[string]interface{}) map[string]int
 	return response
 }
 
-func sendSampleTransaction(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func sendSampleTransaction(cmd map[string]interface{}) map[string]interface{} {
 	var response map[string]interface{}
 	id := cmd["id"]
 	params, err := base64.StdEncoding.DecodeString(cmd["params"].([]interface{})[0].(string))
@@ -349,7 +348,7 @@ func sendSampleTransaction(req *http.Request, cmd map[string]interface{}) map[st
 	return responsePacking(txHashHex, id)
 }
 
-func setDebugInfo(req *http.Request, cmd map[string]interface{}) map[string]interface{} {
+func setDebugInfo(cmd map[string]interface{}) map[string]interface{} {
 	id := cmd["id"]
 	param := cmd["params"].([]interface{})[0].(float64)
 	level := int(param)

--- a/net/httpjsonrpc/sampleTransaction.go
+++ b/net/httpjsonrpc/sampleTransaction.go
@@ -45,11 +45,14 @@ func NewIssueTx(admin *client.Account, hash Uint256) *transaction.Transaction {
 
 func NewTransferTx(regHash, issueHash Uint256, toUser *client.Account) *transaction.Transaction {
 	tx, _ := transaction.NewTransferAssetTransaction()
-	transferUTXOInput := &transaction.UTXOTxInput{
-		ReferTxID:          issueHash,
-		ReferTxOutputIndex: uint16(0),
-	}
-	tx.UTXOInputs = append(tx.UTXOInputs, transferUTXOInput)
+	// TODO: fill the UTXO inputs after TX inputs verification works
+	/*
+		transferUTXOInput := &transaction.UTXOTxInput{
+			ReferTxID:          issueHash,
+			ReferTxOutputIndex: uint16(0),
+		}
+		tx.UTXOInputs = append(tx.UTXOInputs, transferUTXOInput)
+	*/
 	temp, err := toUser.PublicKey.EncodePoint(true)
 	if err != nil {
 		log.Error("EncodePoint error.")

--- a/net/httpjsonrpc/sampleTransaction.go
+++ b/net/httpjsonrpc/sampleTransaction.go
@@ -1,0 +1,88 @@
+package httpjsonrpc
+
+import (
+	"DNA/client"
+	. "DNA/common"
+	"DNA/common/log"
+	. "DNA/core/asset"
+	"DNA/core/contract"
+	"DNA/core/signature"
+	"DNA/core/transaction"
+	"strconv"
+)
+
+const (
+	ASSETPREFIX = "DNA"
+)
+
+func NewRegTx(rand string, index int, admin, issuer *client.Account) *transaction.Transaction {
+	name := ASSETPREFIX + "-" + strconv.Itoa(index) + "-" + rand
+	asset := &Asset{name, byte(0x00), AssetType(Share), UTXO}
+	amount := Fixed64(1000)
+	controller, _ := contract.CreateSignatureContract(admin.PubKey())
+	tx, _ := transaction.NewRegisterAssetTransaction(asset, amount, issuer.PubKey(), controller.ProgramHash)
+	return tx
+}
+
+func NewIssueTx(admin *client.Account, hash Uint256) *transaction.Transaction {
+	tx, _ := transaction.NewIssueAssetTransaction()
+	temp, err := admin.PublicKey.EncodePoint(true)
+	if err != nil {
+		log.Error("EncodePoint error.")
+	}
+	hashx, err := ToCodeHash(temp)
+	if err != nil {
+		log.Error("TocodeHash hash error.")
+	}
+	issueTxOutput := &transaction.TxOutput{
+		AssetID:     hash,
+		Value:       Fixed64(100),
+		ProgramHash: hashx,
+	}
+	tx.Outputs = append(tx.Outputs, issueTxOutput)
+	return tx
+}
+
+func NewTransferTx(regHash, issueHash Uint256, toUser *client.Account) *transaction.Transaction {
+	tx, _ := transaction.NewTransferAssetTransaction()
+	transferUTXOInput := &transaction.UTXOTxInput{
+		ReferTxID:          issueHash,
+		ReferTxOutputIndex: uint16(0),
+	}
+	tx.UTXOInputs = append(tx.UTXOInputs, transferUTXOInput)
+	temp, err := toUser.PublicKey.EncodePoint(true)
+	if err != nil {
+		log.Error("EncodePoint error.")
+	}
+	hashx, err := ToCodeHash(temp)
+	if err != nil {
+		log.Error("TocodeHash hash error.")
+	}
+	transferTxOutput := &transaction.TxOutput{
+		AssetID:     regHash,
+		Value:       Fixed64(100),
+		ProgramHash: hashx,
+	}
+	tx.Outputs = append(tx.Outputs, transferTxOutput)
+	return tx
+}
+
+func SignTx(admin *client.Account, tx *transaction.Transaction) {
+	signdate, err := signature.SignBySigner(tx, admin)
+	if err != nil {
+		log.Error(err, "signdate SignBySigner failed")
+	}
+	transactionContract, _ := contract.CreateSignatureContract(admin.PublicKey)
+	transactionContractContext := contract.NewContractContext(tx)
+	transactionContractContext.AddContract(transactionContract, admin.PublicKey, signdate)
+	tx.SetPrograms(transactionContractContext.GetPrograms())
+}
+
+func SendTx(tx *transaction.Transaction) {
+	if !node.AppendTxnPool(tx) {
+		log.Warn("Can NOT add the transaction to TxnPool")
+	}
+	if err := node.Xmit(tx); err != nil {
+		log.Error("Xmit Tx Error")
+	}
+}

--- a/utility/common.go
+++ b/utility/common.go
@@ -39,7 +39,7 @@ type Param struct {
 	Start           bool   // start service
 	Stop            bool   // stop service
 	NodeState       bool   // node state
-	Tx              bool   // Transaction test case
+	Tx              string // Transaction test case
 	TxNum           int64  // count of transaction
 	NoSign          bool   // transaction is not signed
 	DebugLevel      int    // transaction is not signed
@@ -61,7 +61,7 @@ func registerFlags(f *flag.FlagSet) {
 	f.BoolVar(&p.Neighbor, "neighbor", false, "neighbor nodes information")
 	f.BoolVar(&p.NodeState, "state", false, "node state")
 	f.BoolVar(&p.Start, "start", false, "start service")
-	f.BoolVar(&p.Tx, "tx", false, "send a sample transaction")
+	f.StringVar(&p.Tx, "tx", "full", "send sample transaction with different type (full/perf)")
 	f.Int64Var(&p.TxNum, "num", 1, "transaction number")
 	f.BoolVar(&p.NoSign, "nosign", false, "send unsigned transaction")
 	f.BoolVar(&p.Stop, "stop", false, "stop service")

--- a/utility/test/test.go
+++ b/utility/test/test.go
@@ -1,27 +1,10 @@
 package test
 
 import (
-	"DNA/client"
-	. "DNA/common"
-	. "DNA/core/asset"
-	"DNA/core/contract"
-	"DNA/core/signature"
-	"DNA/core/transaction"
 	"DNA/net/httpjsonrpc"
 	"DNA/utility"
-	"bytes"
-	_"crypto/sha256"
 	"fmt"
-	"math/rand"
 	"os"
-	"strconv"
-	"DNA/common/log"
-	"time"
-)
-
-const (
-	RANDBYTELEN = 32
-	ASSETPREFIX = "DNA :"
 )
 
 var usage = `run sample routines`
@@ -29,192 +12,16 @@ var usage = `run sample routines`
 var flags = []string{"tx", "num", "nosign"}
 
 func testMain(args []string, p utility.Param) (err error) {
-	if p.Tx {
-		issuer, err := client.NewAccount()
+	if txType := p.Tx; txType != "" {
+		resp, err := httpjsonrpc.Call(utility.Address(p.Ip, p.Port), "sendsampletransaction",
+			p.RPCID, []interface{}{p.Tx, p.TxNum, p.NoSign})
 		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
 			return err
 		}
-		admin := issuer
-
-		rbuf := make([]byte, RANDBYTELEN)
-		rand.Read(rbuf)
-		//assetid := Uint256(sha256.Sum256(rbuf))
-		var regHash Uint256
-		var issueHash Uint256
-		var index int64
-		for index = 0; index < p.TxNum; index++ {
-			// RegisterAsset
-			{
-				tx := sampleTransaction(issuer, admin, index, rbuf, p.NoSign)
-				buf := new(bytes.Buffer)
-				err = tx.Serialize(buf)
-				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					return err
-				}
-				regHash = tx.Hash()
-				resp, err := httpjsonrpc.Call(utility.Address(p.Ip, p.Port), "sendsampletransaction", p.RPCID, []interface{}{buf.Bytes()})
-				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					return err
-				}
-
-				utility.FormatOutput(resp)
-			}
-			time.Sleep(5 * time.Second)
-			//IssueAsset
-			{
-				tx := sampleTransactionIssue(admin, regHash)
-				buf := new(bytes.Buffer)
-				err = tx.Serialize(buf)
-				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					return err
-				}
-				issueHash = tx.Hash()
-				resp, err := httpjsonrpc.Call(utility.Address(p.Ip, p.Port), "sendsampletransaction", p.RPCID, []interface{}{buf.Bytes()})
-				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					return err
-				}
-				utility.FormatOutput(resp)
-
-			}
-			time.Sleep(5 * time.Second)
-			//TransferAsset
-			{
-				tx := sampleTransactionTransfer(issuer, admin, regHash, issueHash)
-				buf := new(bytes.Buffer)
-				err = tx.Serialize(buf)
-				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					return err
-				}
-				resp, err := httpjsonrpc.Call(utility.Address(p.Ip, p.Port), "sendsampletransaction", p.RPCID, []interface{}{buf.Bytes()})
-				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					return err
-				}
-				utility.FormatOutput(resp)
-			}
-		}
-		var out bytes.Buffer
-		out.Write([]byte(fmt.Sprintf("hash issue:%x\n",regHash)))
-		out.Write([]byte(fmt.Sprintf("hash transfer:%x\n",issueHash)))
-		out.Write([]byte("\n"))
-		_, err = out.WriteTo(os.Stdout)
+		utility.FormatOutput(resp)
 	}
-
 	return nil
-}
-
-func sampleTransaction(issuer, admin *client.Account, index int64,buf []byte, nosign bool) *transaction.Transaction {
-	// generate asset
-	a := SampleAsset(index,buf)
-	// generate controllerPGM
-	controllerPGM, _ := contract.CreateSignatureContract(admin.PubKey())
-	// generate transaction
-	ammount := Fixed64(1000)
-	tx, _ := transaction.NewRegisterAssetTransaction(a, ammount, issuer.PubKey(), controllerPGM.ProgramHash)
-	if nosign {
-		return tx
-	}
-	// generate signature
-	signdate, err := signature.SignBySigner(tx, issuer)
-	if err != nil {
-		fmt.Println(err, "signdate SignBySigner failed")
-	}
-	// create & add contract
-	transactionContract, _ := contract.CreateSignatureContract(issuer.PubKey())
-	transactionContractContext := contract.NewContractContext(tx)
-	transactionContractContext.AddContract(transactionContract, issuer.PublicKey, signdate)
-	// get ContractContext Programs & set into transaction
-	tx.SetPrograms(transactionContractContext.GetPrograms())
-	return tx
-}
-
-func sampleTransactionIssue(admin *client.Account,hash Uint256) *transaction.Transaction {
-	// generate transaction
-	tx, _ := transaction.NewIssueAssetTransaction()
-	// generate signature
-	signdate, err := signature.SignBySigner(tx, admin)
-	if err != nil {
-		fmt.Println(err, "signdate SignBySigner failed")
-	}
-
-	// create & add contract
-	transactionContract, _ := contract.CreateSignatureContract(admin.PublicKey)
-	transactionContractContext := contract.NewContractContext(tx)
-	transactionContractContext.AddContract(transactionContract, admin.PublicKey, signdate)
-
-	//UTXO　Output generate.
-	temp,err := admin.PublicKey.EncodePoint(true)
-	if err !=nil{
-		log.Debug("EncodePoint error.")
-	}
-	hashx ,err  := ToCodeHash(temp)
-	if err != nil {
-		log.Debug("TocodeHash hash error.")
-	}
-	issueTxOutput := &transaction.TxOutput{
-		AssetID:hash,
-		Value: Fixed64(100),
-		ProgramHash:hashx,
-	}
-	tx.Outputs = append(tx.Outputs,issueTxOutput)
-
-	// get ContractContext Programs & set into transaction
-	tx.SetPrograms(transactionContractContext.GetPrograms())
-	return tx
-}
-
-func sampleTransactionTransfer(toUser, admin *client.Account,regHash Uint256,issueHash Uint256) *transaction.Transaction {
-	// generate transaction
-	tx, _ := transaction.NewTransferAssetTransaction()
-	// generate signature
-	signdate, err := signature.SignBySigner(tx, admin)
-	if err != nil {
-		fmt.Println(err, "signdate SignBySigner failed")
-	}
-	// create & add contract
-	transactionContract, _ := contract.CreateSignatureContract(admin.PublicKey)
-	transactionContractContext := contract.NewContractContext(tx)
-	transactionContractContext.AddContract(transactionContract, admin.PublicKey, signdate)
-
-	//UTXO  INPUT Generate.
-	transferUTXOInput := &transaction.UTXOTxInput{
-		ReferTxID:issueHash,
-		//The index of output in the referTx output list
-		ReferTxOutputIndex:uint16(0),
-	}
-	tx.UTXOInputs = append(tx.UTXOInputs,transferUTXOInput)
-
-	//UTXO　Output generate.
-	temp,err := toUser.PublicKey.EncodePoint(true)
-	if err !=nil{
-		log.Debug("EncodePoint error.")
-	}
-	hashx ,err  := ToCodeHash(temp)
-	if err != nil {
-		log.Debug("TocodeHash hash error.")
-	}
-	issueTxOutput := &transaction.TxOutput{
-		AssetID:regHash,
-		Value: Fixed64(100),
-		ProgramHash:hashx,
-	}
-	tx.Outputs = append(tx.Outputs,issueTxOutput)
-
-	// get ContractContext Programs & set into transaction
-	tx.SetPrograms(transactionContractContext.GetPrograms())
-	return tx
-}
-
-
-func SampleAsset( index int64,buf []byte) *Asset {
-	name := ASSETPREFIX + string(buf) + strconv.FormatInt(index,10)
-	asset := Asset{name, byte(0x00), AssetType(Share), UTXO}
-	return &asset
 }
 
 var Command = &utility.Command{UsageText: usage, Flags: flags, Main: testMain}


### PR DESCRIPTION
1. Fix client name typo
2. Support setting the log level to 'maxprintlevel'
3. Move the sample transaction to node side, nodectl supports two ways to send tx: 
   a) performance testing transactions
   b) register/issue/transfer transactions
4. Workaround UTXO inputs verification issue since it stops generating block 
5. Remove the unnecessary input http.Request parameter  