### PR TITLE
change getheaders message logic

### DIFF
--- a/net/message/message.go
+++ b/net/message/message.go
@@ -181,7 +181,7 @@ func NewMsg(t string, n Noder) ([]byte, error) {
 	case "verack":
 		return NewVerack()
 	case "getheaders":
-		return NewHeadersReq(n)
+		return NewHeadersReq()
 	case "getaddr":
 		return newGetAddr()
 

--- a/net/message/verack.go
+++ b/net/message/verack.go
@@ -74,24 +74,24 @@ func (msg verACK) Handle(node Noder) error {
 	// node which will trigger a warning
 	node.ReqNeighborList()
 
-	// FIXME compact to a seperate function
-	if uint64(ledger.DefaultLedger.Blockchain.BlockHeight) < node.GetHeight() {
-		/*
-			buf, err := NewHeadersReq(node)
-			if err != nil {
-				log.Error("failed build a new headersReq")
-			} else {
-				go node.Tx(buf)
-			}
+	// The getheaders process haven't finished yet. So add comments now.
 
-		*/
+	/*
+		if uint64(ledger.DefaultLedger.Store.GetHeaderHeight()) < node.GetHeight() {
+			if node.LocalNode().IsSyncHeaders() == false {
+				SendMsgSyncHeaders(node)
+				node.StartRetryTimer()
+			}
+		}
+	*/
+	if uint64(ledger.DefaultLedger.Blockchain.BlockHeight) < node.GetHeight() {
 		buf, err := NewBlocksReq(node)
 		if err != nil {
 			log.Error("failed build a new blockReq")
 		} else {
 			go node.Tx(buf)
 		}
-
 	}
+
 	return nil
 }

--- a/net/node/nodeMap.go
+++ b/net/node/nodeMap.go
@@ -118,8 +118,7 @@ func (node *node) GetNeighborHeights() ([]uint64, uint64) {
 	defer node.nbrNodes.RUnlock()
 
 	var i uint64
-	var heights []uint64
-	heights = make([]uint64, 1)
+	heights := []uint64{}
 	for _, n := range node.nbrNodes.List {
 		if n.GetState() == ESTABLISH {
 			height := n.GetHeight()
@@ -128,4 +127,18 @@ func (node *node) GetNeighborHeights() ([]uint64, uint64) {
 		}
 	}
 	return heights, i
+}
+
+func (node *node) GetNeighborNoder() []Noder {
+	node.nbrNodes.RLock()
+	defer node.nbrNodes.RUnlock()
+
+	nodes := []Noder{}
+	for _, n := range node.nbrNodes.List {
+		if n.GetState() == ESTABLISH {
+			node := n
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes
 }

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -91,6 +91,14 @@ type Noder interface {
 	GetNeighborHeights() ([]uint64, uint64)
 	SyncNodeHeight()
 	CleanSubmittedTransactions(block *ledger.Block) error
+
+	IsSyncHeaders() bool
+	SetSyncHeaders(b bool)
+	IsSyncFailed() bool
+	SetSyncFailed()
+	StartRetryTimer()
+	StopRetryTimer()
+	GetNeighborNoder() []Noder
 }
 
 type JsonNoder interface {


### PR DESCRIPTION
Send getheaders message when the local block height is less
than others and receive verack message.
If the other node block height is more than 2000, send
getheaders request again after receive blkheader from other
node and verify the previous headers are valid.
If the previous headers are invalid, send getheaders request
to another node.
Send getblock message until the block headers finish sync up.

Signed-off-by: Jin Qing <1091147665@qq.com>