### PR TITLE
Fixed the bug of block SerializeUnsigned.

### DIFF
--- a/core/ledger/block.go
+++ b/core/ledger/block.go
@@ -210,9 +210,5 @@ func (b *Block) RebuildMerkleRoot() error {
 }
 
 func (bd *Block) SerializeUnsigned(w io.Writer) error {
-	/*
-	* TODO Just Add for interface of signableDate.
-	* 2017/2/27 luodanwg
-	* */
-	return nil
+	return bd.Blockdata.SerializeUnsigned(w)
 }


### PR DESCRIPTION
Fixed the bug of block SerializeUnsigned.

The block SerializeUnsigned is still in blank, so the block signBySigner
func is sign a nil data now.
Have tested with 10W transactions with no error.

Signed-off-by: junjie <luodan.wg@gmail.com>