### PR TITLE
User can config the miner count at the beginning

### DIFF
--- a/client/account.go
+++ b/client/account.go
@@ -1,63 +1,62 @@
 package client
 
 import (
-	"DNA/crypto"
 	. "DNA/common"
+	"DNA/crypto"
 	. "DNA/errors"
 	"errors"
 )
 
 type Account struct {
-	PrivateKey []byte
-	PublicKey *crypto.PubKey
+	PrivateKey    []byte
+	PublicKey     *crypto.PubKey
 	PublicKeyHash Uint160
 }
 
-func NewAccount() (*Account, error){
-
-	priKey,pubKey,_ := crypto.GenKeyPair()
-	temp,err := pubKey.EncodePoint(true)
-	if err !=nil{
-		return nil,NewDetailErr(err, ErrNoCode, "[Contract],CreateSignatureContract failed.")
+func NewAccount() (*Account, error) {
+	priKey, pubKey, _ := crypto.GenKeyPair()
+	temp, err := pubKey.EncodePoint(true)
+	if err != nil {
+		return nil, NewDetailErr(err, ErrNoCode, "[Contract],CreateSignatureContract failed.")
 	}
-	hash ,err  := ToCodeHash(temp)
-	if err !=nil{
-		return nil,NewDetailErr(err, ErrNoCode, "[Contract],CreateSignatureContract failed.")
+	hash, err := ToCodeHash(temp)
+	if err != nil {
+		return nil, NewDetailErr(err, ErrNoCode, "[Contract],CreateSignatureContract failed.")
 	}
 	return &Account{
-		PrivateKey: priKey,
-		PublicKey: &pubKey,
+		PrivateKey:    priKey,
+		PublicKey:     &pubKey,
 		PublicKeyHash: hash,
-	},nil
+	}, nil
 }
 
-func NewAccountWithPrivatekey(privateKey []byte) (*Account, error){
+func NewAccountWithPrivatekey(privateKey []byte) (*Account, error) {
 	privKeyLen := len(privateKey)
 
 	if privKeyLen != 32 && privKeyLen != 96 && privKeyLen != 104 {
-		return nil,errors.New("Invalid private Key.")
+		return nil, errors.New("Invalid private Key.")
 	}
 
 	// set public key
 	pubKey := crypto.NewPubKey(privateKey)
 	//priKey,pubKey,_ := crypto.GenKeyPair()
-	temp,err := pubKey.EncodePoint(true)
-	if err !=nil{
-		return nil,NewDetailErr(err, ErrNoCode, "[Contract],CreateSignatureContract failed.")
+	temp, err := pubKey.EncodePoint(true)
+	if err != nil {
+		return nil, NewDetailErr(err, ErrNoCode, "[Contract],CreateSignatureContract failed.")
 	}
-	hash ,err  := ToCodeHash(temp)
-	if err !=nil{
-		return nil,NewDetailErr(err, ErrNoCode, "[Contract],CreateSignatureContract failed.")
+	hash, err := ToCodeHash(temp)
+	if err != nil {
+		return nil, NewDetailErr(err, ErrNoCode, "[Contract],CreateSignatureContract failed.")
 	}
 	return &Account{
-		PrivateKey: privateKey,
-		PublicKey: pubKey,
+		PrivateKey:    privateKey,
+		PublicKey:     pubKey,
 		PublicKeyHash: hash,
-	},nil
+	}, nil
 }
 
 //get signer's private key
-func (ac *Account) PrivKey() []byte{
+func (ac *Account) PrivKey() []byte {
 	return ac.PrivateKey
 }
 
@@ -65,6 +64,7 @@ func (ac *Account) PrivKey() []byte{
 func (ac *Account) PubKey() *crypto.PubKey {
 	return ac.PublicKey
 }
+
 /*
 func (ac *Account) ToAddress(scriptHash Uint160) string {
 	//fmt.Printf( "%x\n", scriptHash )

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type ProtocolConfiguration struct {
 	KeyPath       string   `json:"KeyPath"`
 	CAPath        string   `json:"CAPath"`
 	GenBlockTime  uint     `json:"GenBlockTime"`
+	MinerCount    uint32   `json:"MinerCount"`
 }
 
 type ProtocolFile struct {

--- a/config/config.json
+++ b/config/config.json
@@ -3,16 +3,17 @@
     "Magic": 7630401,
     "CoinVersion": 23,
     "SeedList": [
-      "192.168.33.11:20338"
+      "10.0.1.100:20438"
     ],
-    "HttpJsonPort": 20336,
-    "HttpLocalPort": 20337,
-    "NodePort": 20338,
-    "MinerName": "c1",
-    "PrintLevel": 0,
+    "HttpJsonPort": 20436,
+    "HttpLocalPort": 20437,
+    "NodePort": 20438,
+    "MinerName": "c4",
+    "PrintLevel": 2,
     "IsTLS": false,
     "CertPath": "./sample-cert.pem",
     "KeyPath": "./sample-cert-key.pem",
-    "CAPath": "./sample-ca.pem"
+    "CAPath": "./sample-ca.pem",
+    "MinerCount": 4
   }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -3,13 +3,13 @@
     "Magic": 7630401,
     "CoinVersion": 23,
     "SeedList": [
-      "10.0.1.100:20438"
+      "127.0.0.1:20338"
     ],
-    "HttpJsonPort": 20436,
-    "HttpLocalPort": 20437,
-    "NodePort": 20438,
-    "MinerName": "c4",
-    "PrintLevel": 2,
+    "HttpJsonPort": 20336,
+    "HttpLocalPort": 20337,
+    "NodePort": 20338,
+    "MinerName": "c1",
+    "PrintLevel": 0,
     "IsTLS": false,
     "CertPath": "./sample-cert.pem",
     "KeyPath": "./sample-cert-key.pem",

--- a/core/store/LevelDBStore/LevelDBStore.go
+++ b/core/store/LevelDBStore/LevelDBStore.go
@@ -28,7 +28,7 @@ type LevelDBStore struct {
 
 	headerIndex map[uint32]Uint256
 	blockCache  map[Uint256]*Block
-  	headerCache map[Uint256]*Header
+	headerCache map[Uint256]*Header
 
 	currentBlockHeight uint32
 	storedHeaderCount  uint32
@@ -64,7 +64,7 @@ func NewLevelDBStore(file string) (*LevelDBStore, error) {
 		it:                 nil,
 		headerIndex:        map[uint32]Uint256{},
 		blockCache:         map[Uint256]*Block{},
-    		headerCache:         map[Uint256]*Header{},
+		headerCache:        map[Uint256]*Header{},
 		currentBlockHeight: 0,
 		storedHeaderCount:  0,
 		disposed:           false,
@@ -348,9 +348,6 @@ func (bd *LevelDBStore) GetContract(hash []byte) ([]byte, error) {
 }
 
 func (bd *LevelDBStore) GetHeaderWithCache(hash Uint256) *Header {
-	bd.mu.RLock()
-	defer bd.mu.RUnlock()
-
 	if _, ok := bd.headerCache[hash]; ok {
 		return bd.headerCache[hash]
 	}
@@ -362,7 +359,11 @@ func (bd *LevelDBStore) GetHeaderWithCache(hash Uint256) *Header {
 
 func (bd *LevelDBStore) containsBlock(hash Uint256) bool {
 	header := bd.GetHeaderWithCache(hash)
-	return header.Blockdata.Height <= bd.currentBlockHeight
+	if header != nil {
+		return header.Blockdata.Height <= bd.currentBlockHeight
+	} else {
+		return false
+	}
 }
 
 func (bd *LevelDBStore) VerifyHeader(header *Header) bool {
@@ -408,6 +409,7 @@ func (bd *LevelDBStore) AddHeaders(headers []Header, ledger *Ledger) error {
 
 		//header verify
 		if !bd.VerifyHeader(&headers[i]) {
+			log.Error("Verify header failed")
 			break
 		}
 

--- a/main.go
+++ b/main.go
@@ -19,7 +19,8 @@ import (
 
 const (
 	// The number of the CPU cores for parallel optimization,TODO set from config file
-	NCPU = 4
+	NCPU              = 4
+	DefaultMinerCount = 4
 )
 
 var Version string
@@ -70,7 +71,10 @@ func main() {
 	fmt.Println("//**************************************************************************")
 	fmt.Println("//*** 1. Generate [Account]                                              ***")
 	fmt.Println("//**************************************************************************")
-	minerCount := config.Parameters.MinerCount
+	var minerCount uint32 = DefaultMinerCount
+	if config.Parameters.MinerCount != 0 {
+		minerCount = config.Parameters.MinerCount
+	}
 	localclient := OpenClientAndGetAccount(minerCount)
 	if localclient == nil {
 		fmt.Println("Can't get local client.")


### PR DESCRIPTION
User can config the miner count at the beginning of
starting the system by setting MinerCount in
config.json.
eg. If MinerCount is 5, the minername for four peers
should be c1, c2, c3, c4, c5.

Signed-off-by: Jin Qing <1091147665@qq.com>