### PR TITLE
Broadcast INV message rather than full block

### DIFF
--- a/consensus/dbft/dbftService.go
+++ b/consensus/dbft/dbftService.go
@@ -119,10 +119,6 @@ func (ds *DbftService) AddTransaction(TX *tx.Transaction, needVerify bool) error
 			}
 			payload := ds.context.MakePrepareResponse(ds.context.Signatures[ds.context.MinerIndex])
 			ds.SignAndRelay(payload)
-			err = ds.CheckSignatures()
-			if err != nil {
-				return NewDetailErr(err, ErrNoCode, "[DbftService] ,CheckSignatures failed.")
-			}
 		} else {
 			ds.RequestChangeView()
 			return errors.New("No valid Next Miner.")

--- a/core/ledger/ledger.go
+++ b/core/ledger/ledger.go
@@ -1,14 +1,14 @@
 package ledger
 
 import (
+	"DNA/common"
 	. "DNA/common"
+	"DNA/core/asset"
+	"DNA/core/contract"
 	tx "DNA/core/transaction"
 	"DNA/crypto"
 	. "DNA/errors"
 	"errors"
-	"DNA/core/asset"
-	"DNA/core/contract"
-	"DNA/common"
 )
 
 var DefaultLedger *Ledger
@@ -36,7 +36,7 @@ func GetDefaultLedger() (*Ledger, error) {
 }
 
 //Calc the Miners address by miners pubkey.
-func GetMinerAddress(miners []*crypto.PubKey) (Uint160,error) {
+func GetMinerAddress(miners []*crypto.PubKey) (Uint160, error) {
 	//TODO: GetMinerAddress()
 	//return Uint160{}
 	//CreateSignatureRedeemScript
@@ -46,7 +46,7 @@ func GetMinerAddress(miners []*crypto.PubKey) (Uint160,error) {
 	var temp []byte
 	var err error
 	if len(miners) > 1 {
-		temp, err = contract.CreateMultiSigRedeemScript(len(miners) - (len(miners) - 1) / 3, miners)
+		temp, err = contract.CreateMultiSigRedeemScript(len(miners)-(len(miners)-1)/3, miners)
 		if err != nil {
 			return Uint160{}, NewDetailErr(err, ErrNoCode, "[Ledger],GetMinerAddress failed with CreateMultiSigRedeemScript.")
 		}
@@ -56,31 +56,31 @@ func GetMinerAddress(miners []*crypto.PubKey) (Uint160,error) {
 			return Uint160{}, NewDetailErr(err, ErrNoCode, "[Ledger],GetMinerAddress failed with CreateMultiSigRedeemScript.")
 		}
 	}
-	codehash ,err:=common.ToCodeHash(temp)
-	if err != nil{
-		return Uint160{},NewDetailErr(err, ErrNoCode, "[Ledger],GetMinerAddress failed with ToCodeHash.")
+	codehash, err := common.ToCodeHash(temp)
+	if err != nil {
+		return Uint160{}, NewDetailErr(err, ErrNoCode, "[Ledger],GetMinerAddress failed with ToCodeHash.")
 	}
-	return codehash,nil
+	return codehash, nil
 }
 
 //Get the Asset from store.
-func (l *Ledger) GetAsset(assetId Uint256) (*asset.Asset,error) {
+func (l *Ledger) GetAsset(assetId Uint256) (*asset.Asset, error) {
 	asset, err := l.Store.GetAsset(assetId)
-	if err != nil{
-		return nil,NewDetailErr(err, ErrNoCode, "[Ledger],GetAsset failed with assetId ="+ assetId.ToString())
+	if err != nil {
+		return nil, NewDetailErr(err, ErrNoCode, "[Ledger],GetAsset failed with assetId ="+assetId.ToString())
 	}
-	return asset,nil
+	return asset, nil
 }
 
 //Get Block With Height.
 func (l *Ledger) GetBlockWithHeight(height uint32) (*Block, error) {
 	temp, err := l.Store.GetBlockHash(height)
-	if err != nil{
-		return nil,NewDetailErr(err, ErrNoCode, "[Ledger],GetBlockWithHeight failed with height="+ string(height))
+	if err != nil {
+		return nil, NewDetailErr(err, ErrNoCode, "[Ledger],GetBlockWithHeight failed with height="+string(height))
 	}
 	bk, err := DefaultLedger.Store.GetBlock(temp)
 	if err != nil {
-		return nil,NewDetailErr(err, ErrNoCode, "[Ledger],GetBlockWithHeight failed with hash="+ temp.ToString())
+		return nil, NewDetailErr(err, ErrNoCode, "[Ledger],GetBlockWithHeight failed with hash="+temp.ToString())
 	}
 	return bk, nil
 }
@@ -89,21 +89,30 @@ func (l *Ledger) GetBlockWithHeight(height uint32) (*Block, error) {
 func (l *Ledger) GetBlockWithHash(hash Uint256) (*Block, error) {
 	bk, err := l.Store.GetBlock(hash)
 	if err != nil {
-		return nil,NewDetailErr(err, ErrNoCode, "[Ledger],GetBlockWithHeight failed with hash="+ hash.ToString())
+		return nil, NewDetailErr(err, ErrNoCode, "[Ledger],GetBlockWithHeight failed with hash="+hash.ToString())
 	}
 	return bk, nil
+}
+
+//ContainBlock checks if the block existed in ledger
+func (l *Ledger) ContainBlock(hash Uint256) bool {
+	bk, _ := l.Store.GetBlock(hash)
+	if bk == nil {
+		return false
+	}
+	return true
 }
 
 //Get transaction with hash.
 func (l *Ledger) GetTransactionWithHash(hash Uint256) (*tx.Transaction, error) {
 	tx, err := l.Store.GetTransaction(hash)
-	if err != nil{
-		return nil,NewDetailErr(err, ErrNoCode, "[Ledger],GetTransactionWithHash failed with hash="+ hash.ToString())
+	if err != nil {
+		return nil, NewDetailErr(err, ErrNoCode, "[Ledger],GetTransactionWithHash failed with hash="+hash.ToString())
 	}
 	return tx, nil
 }
 
 //Get local block chain height.
-func (l *Ledger) GetLocalBlockChainHeight() uint32{
+func (l *Ledger) GetLocalBlockChainHeight() uint32 {
 	return l.Blockchain.BlockHeight
 }

--- a/core/ledger/ledger.go
+++ b/core/ledger/ledger.go
@@ -94,8 +94,8 @@ func (l *Ledger) GetBlockWithHash(hash Uint256) (*Block, error) {
 	return bk, nil
 }
 
-//ContainBlock checks if the block existed in ledger
-func (l *Ledger) ContainBlock(hash Uint256) bool {
+//BlockInLedger checks if the block existed in ledger
+func (l *Ledger) BlockInLedger(hash Uint256) bool {
 	bk, _ := l.Store.GetBlock(hash)
 	if bk == nil {
 		return false

--- a/core/ledger/ledgerStore.go
+++ b/core/ledger/ledgerStore.go
@@ -9,8 +9,9 @@ import (
 // ILedgerStore provides func with store package.
 type ILedgerStore interface {
 	//TODO: define the state store func
-	SaveBlock(b *Block,ledger *Ledger) error
+	SaveBlock(b *Block, ledger *Ledger) error
 	GetBlock(hash Uint256) (*Block, error)
+	BlockInCache(hash Uint256) bool
 	GetBlockHash(height uint32) (Uint256, error)
 	InitLedgerStore(ledger *Ledger) error
 	IsDoubleSpend(tx *tx.Transaction) bool
@@ -19,9 +20,9 @@ type ILedgerStore interface {
 	AddHeaders(headers []Header, ledger *Ledger) error
 	GetHeader(hash Uint256) (*Header, error)
 
-	GetTransaction(hash Uint256) (*tx.Transaction,error)
+	GetTransaction(hash Uint256) (*tx.Transaction, error)
 
-	SaveAsset(assetid Uint256,asset *Asset) error
+	SaveAsset(assetid Uint256, asset *Asset) error
 	GetAsset(hash Uint256) (*Asset, error)
 
 	GetCurrentBlockHash() Uint256
@@ -32,10 +33,10 @@ type ILedgerStore interface {
 
 	Close() error
 
-	InitLevelDBStoreWithGenesisBlock( genesisblock * Block  ) (uint32, error)
+	InitLevelDBStoreWithGenesisBlock(genesisblock *Block) (uint32, error)
 
 	GetQuantityIssued(assetid Uint256) (Fixed64, error)
 
 	GetUnspent(txid Uint256, index uint16) (*tx.TxOutput, error)
-	ContainsUnspent(txid Uint256, index uint16) (bool,error)
+	ContainsUnspent(txid Uint256, index uint16) (bool, error)
 }

--- a/core/store/LevelDBStore/LevelDBStore.go
+++ b/core/store/LevelDBStore/LevelDBStore.go
@@ -881,10 +881,8 @@ func (bd *LevelDBStore) onAddHeader(header *Header, batch *leveldb.Batch) {
 }
 
 func (bd *LevelDBStore) persistBlocks(ledger *Ledger) {
-
 	bd.mu.Lock()
 	defer bd.mu.Unlock()
-
 	for !bd.disposed {
 		if uint32(len(bd.headerIndex)) < bd.currentBlockHeight+1 {
 			log.Warn("[persistBlocks]: warn, headerIndex.count < currentBlockHeight + 1")
@@ -952,6 +950,15 @@ func (bd *LevelDBStore) SaveBlock(b *Block, ledger *Ledger) error {
 	}
 
 	return nil
+}
+
+func (db *LevelDBStore) BlockInCache(hash Uint256) bool {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+	if _, ok := db.blockCache[hash]; ok {
+		return true
+	}
+	return false
 }
 
 func (bd *LevelDBStore) GetQuantityIssued(assetId Uint256) (Fixed64, error) {

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func main() {
 
 	time.Sleep(2 * time.Second)
 	for {
-		log.Debug("ledger.DefaultLedger.Blockchain.BlockHeight= ", ledger.DefaultLedger.Blockchain.BlockHeight)
+		fmt.Println("ledger.DefaultLedger.Blockchain.BlockHeight= ", ledger.DefaultLedger.Blockchain.BlockHeight)
 		time.Sleep(dbft.GenBlockTime)
 	}
 }

--- a/net/message/block.go
+++ b/net/message/block.go
@@ -25,17 +25,15 @@ type block struct {
 }
 
 func (msg block) Handle(node Noder) error {
-	log.Debug()
-
 	log.Debug("RX block message")
-
-	err := ledger.DefaultLedger.Blockchain.AddBlock(&msg.blk)
-	if err != nil {
-		log.Error("Add block error after Received")
-		return errors.New("Add block error after reveived\n")
+	if !ledger.DefaultLedger.ContainBlock(msg.blk.Hash()) {
+		if err := ledger.DefaultLedger.Blockchain.AddBlock(&msg.blk); err != nil {
+			log.Error("Block adding error after Received")
+			return errors.New("Block adding error after reveived")
+		}
+		node.RemoveFlightHeight(msg.blk.Blockdata.Height)
+		node.LocalNode().GetEvent("block").Notify(events.EventNewInventory, &msg.blk)
 	}
-	node.RemoveFlightHeight(msg.blk.Blockdata.Height)
-	node.LocalNode().GetEvent("block").Notify(events.EventNewInventory, &msg.blk)
 	return nil
 }
 

--- a/net/message/block.go
+++ b/net/message/block.go
@@ -27,7 +27,7 @@ type block struct {
 func (msg block) Handle(node Noder) error {
 	log.Debug("RX block message")
 	hash := msg.blk.Hash()
-	if ledger.DefaultLedger.ContainBlock(hash) {
+	if ledger.DefaultLedger.BlockInLedger(hash) {
 		log.Warn("Receive duplicated block: ", hash)
 		return errors.New("Received duplicate block")
 	}

--- a/net/message/block.go
+++ b/net/message/block.go
@@ -26,14 +26,17 @@ type block struct {
 
 func (msg block) Handle(node Noder) error {
 	log.Debug("RX block message")
-	if !ledger.DefaultLedger.ContainBlock(msg.blk.Hash()) {
-		if err := ledger.DefaultLedger.Blockchain.AddBlock(&msg.blk); err != nil {
-			log.Error("Block adding error after Received")
-			return errors.New("Block adding error after reveived")
-		}
-		node.RemoveFlightHeight(msg.blk.Blockdata.Height)
-		node.LocalNode().GetEvent("block").Notify(events.EventNewInventory, &msg.blk)
+	hash := msg.blk.Hash()
+	if ledger.DefaultLedger.ContainBlock(hash) {
+		log.Warn("Receive duplicated block: ", hash)
+		return errors.New("Received duplicate block")
 	}
+	if err := ledger.DefaultLedger.Blockchain.AddBlock(&msg.blk); err != nil {
+		log.Error("Block adding error: ", hash)
+		return err
+	}
+	node.RemoveFlightHeight(msg.blk.Blockdata.Height)
+	node.LocalNode().GetEvent("block").Notify(events.EventNewInventory, &msg.blk)
 	return nil
 }
 

--- a/net/message/consensus.go
+++ b/net/message/consensus.go
@@ -266,7 +266,7 @@ func NewConsensus(cp *ConsensusPayload) ([]byte, error) {
 	buf := bytes.NewBuffer(s[:4])
 	binary.Read(buf, binary.LittleEndian, &(msg.msgHdr.Checksum))
 	msg.msgHdr.Length = uint32(len(b.Bytes()))
-	log.Debug("NewConsensus The message payload length is %d\n", msg.msgHdr.Length)
+	log.Debug("NewConsensus The message payload length is ", msg.msgHdr.Length)
 
 	m, err := msg.Serialization()
 	if err != nil {

--- a/net/message/inventory.go
+++ b/net/message/inventory.go
@@ -132,7 +132,9 @@ func (msg Inv) Handle(node Noder) error {
 		log.Debug("RX inv-block message, hash is ", msg.P.Blk)
 		for i = 0; i < count; i++ {
 			id.Deserialize(bytes.NewReader(msg.P.Blk[HASHLEN*i:]))
-			if !node.ExistedID(id) {
+			// TODO check the ID queue
+			if !ledger.DefaultLedger.Store.BlockInCache(id) &&
+				!ledger.DefaultLedger.BlockInLedger(id) {
 				// send the block request
 				log.Info("inv request block hash: ", id)
 				ReqBlkData(node, id)

--- a/net/message/message.go
+++ b/net/message/message.go
@@ -137,25 +137,25 @@ func AllocMsg(t string, length int) Messager {
 		copy(msg.msgHdr.CMD[0:len(t)], t)
 		return &msg
 	case "alert":
-		errors.New("Not supported message type")
+		log.Warn("Not supported message type - alert")
 		return nil
 	case "merkleblock":
-		errors.New("Not supported message type")
+		log.Warn("Not supported message type - merkleblock")
 		return nil
 	case "notfound":
-		errors.New("Not supported message type")
+		log.Warn("Not supported message type - notfound")
 		return nil
 	case "ping":
-		errors.New("Not supported message type")
+		log.Warn("Not supported message type - ping")
 		return nil
 	case "pong":
-		errors.New("Not supported message type")
+		log.Warn("Not supported message type - pong")
 		return nil
 	case "reject":
-		errors.New("Not supported message type")
+		log.Warn("Not supported message type - reject")
 		return nil
 	default:
-		errors.New("Unknown message type")
+		log.Warn("Unknown message type")
 		return nil
 	}
 }
@@ -199,14 +199,14 @@ func HandleNodeMsg(node Noder, buf []byte, len int) error {
 
 	s, err := MsgType(buf)
 	if err != nil {
-		fmt.Println(err.Error())
+		log.Error("Message type parsing error")
 		return err
 	}
 
 	msg := AllocMsg(s, len)
 	if msg == nil {
-		fmt.Println(err.Error())
-		return err
+		log.Error(fmt.Sprintf("Allocation message %s failed", s))
+		return errors.New("Allocation message failed")
 	}
 	// Todo attach a ndoe pointer to each message
 	// Todo drop the message when verify/deseria packet error

--- a/net/net.go
+++ b/net/net.go
@@ -18,6 +18,8 @@ type Neter interface {
 	GetEvent(eventName string) *events.Event
 	GetMinersAddrs() ([]*crypto.PubKey, uint64)
 	CleanSubmittedTransactions(block *ledger.Block) error
+	GetNeighborNoder() []protocol.Noder
+	Tx(buf []byte)
 }
 
 func StartProtocol(pubKey *crypto.PubKey) (Neter, protocol.Noder) {

--- a/net/net.go
+++ b/net/net.go
@@ -1,7 +1,7 @@
 package net
 
 import (
-	"DNA/common"
+	. "DNA/common"
 	"DNA/config"
 	"DNA/core/ledger"
 	"DNA/core/transaction"
@@ -12,9 +12,9 @@ import (
 )
 
 type Neter interface {
-	GetTxnPool(cleanPool bool) map[common.Uint256]*transaction.Transaction
+	GetTxnPool(cleanPool bool) map[Uint256]*transaction.Transaction
 	SynchronizeTxnPool()
-	Xmit(common.Inventory) error // The transmit interface
+	Xmit(interface{}) error
 	GetEvent(eventName string) *events.Event
 	GetMinersAddrs() ([]*crypto.PubKey, uint64)
 	CleanSubmittedTransactions(block *ledger.Block) error

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -200,7 +200,7 @@ func (node *node) Xmit(inv common.Inventory) error {
 			//transaction.Serialize(tmpBuffer)
 			buffer, err = NewTxn(transaction)
 			if err != nil {
-				log.Warn("Error New Tx message ", err.Error())
+				log.Warn("Error New Tx message: ", err)
 				return err
 			}
 		}
@@ -214,14 +214,15 @@ func (node *node) Xmit(inv common.Inventory) error {
 			return errors.New("Wrong block be Xmit")
 		}
 
-		err := ledger.DefaultLedger.Blockchain.AddBlock(block)
-		if err != nil {
-			log.Error("Add block error before Xmit")
-			return errors.New("Add block error before Xmit")
+		if !ledger.DefaultLedger.ContainBlock(block.Hash()) {
+			if err := ledger.DefaultLedger.Blockchain.AddBlock(block); err != nil {
+				log.Error("Block adding error in Xmit")
+				return errors.New("Block adding error in Xmit")
+			}
 		}
 		buffer, err = NewBlock(block)
 		if err != nil {
-			log.Warn("Error New Block message ", err.Error())
+			log.Warn("Error New Block message: ", err)
 			return err
 		}
 	} else if inv.Type() == common.CONSENSUS {
@@ -230,7 +231,7 @@ func (node *node) Xmit(inv common.Inventory) error {
 		if ret {
 			buffer, err = NewConsensus(payload)
 			if err != nil {
-				log.Warn("Error New consensus message ", err.Error())
+				log.Warn("Error New consensus message: ", err)
 				return err
 			}
 		}

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -85,7 +85,7 @@ type Noder interface {
 	GetTxnCnt() uint64
 	GetRxTxnCnt() uint64
 
-	Xmit(common.Inventory) error
+	Xmit(interface{}) error
 	SynchronizeTxnPool()
 	GetMinerAddr() *crypto.PubKey
 	GetMinersAddrs() ([]*crypto.PubKey, uint64)
@@ -105,13 +105,6 @@ type Noder interface {
 	StoreFlightHeight(height uint32)
 	GetFlightHeightCnt() int
 	RemoveFlightHeight(height uint32)
-}
-
-type JsonNoder interface {
-	GetConnectionCnt() uint
-	GetTxnPool(bool) map[common.Uint256]*transaction.Transaction
-	Xmit(common.Inventory) error
-	GetTransaction(hash common.Uint256) *transaction.Transaction
 }
 
 func (msg *NodeAddr) Deserialization(p []byte) error {


### PR DESCRIPTION
1.  Remove the needless signature checking when receive
prepare request message，the checking will only be done 
after received prepare response message.
2.   Broadcast inv message rather than full block.  Each peer constructs
and saves block by itself then send inv message to other peers. 