### PR TITLE
Sent entire transaction other than transaction hash in Prepare Request

### DIFF
--- a/consensus/dbft/consensusMessage.go
+++ b/consensus/dbft/consensusMessage.go
@@ -3,7 +3,6 @@ package dbft
 import (
 	"DNA/common/log"
 	ser "DNA/common/serialization"
-	tx "DNA/core/transaction"
 	"bytes"
 	"errors"
 	"io"
@@ -28,9 +27,7 @@ func DeserializeMessage(data []byte) (ConsensusMessage, error) {
 	r := bytes.NewReader(data)
 	switch msgType {
 	case PrepareRequestMsg:
-		prMsg := &PrepareRequest{
-			BookkeepingTransaction: new(tx.Transaction),
-		}
+		prMsg := &PrepareRequest{}
 		err := prMsg.Deserialize(r)
 		if err != nil {
 			log.Error("[DeserializeMessage] PrepareRequestMsg Deserialize Error: ", err.Error())

--- a/core/transaction/txAttribute.go
+++ b/core/transaction/txAttribute.go
@@ -65,9 +65,9 @@ type TransactionAttributeUsage byte
 
 const (
 	ContractHash   TransactionAttributeUsage = 0x00
-	ECDH02         TransactionAttributeUsage = 0x02 //用于ECDH密钥交换的公钥，该公钥的第一个字节为0x02
-	ECDH03         TransactionAttributeUsage = 0x03 //用于ECDH密钥交换的公钥，该公钥的第一个字节为0x03
-	Script         TransactionAttributeUsage = 0x20 //用于对交易进行额外的验证
+	ECDH02         TransactionAttributeUsage = 0x02
+	ECDH03         TransactionAttributeUsage = 0x03
+	Script         TransactionAttributeUsage = 0x20
 	Vote           TransactionAttributeUsage = 0x30
 	DescriptionUrl TransactionAttributeUsage = 0x81
 	Description    TransactionAttributeUsage = 0x90
@@ -87,7 +87,7 @@ const (
 	Hash13 TransactionAttributeUsage = 0xad
 	Hash14 TransactionAttributeUsage = 0xae
 	Hash15 TransactionAttributeUsage = 0xaf
-	/// 备注
+
 	Remark   TransactionAttributeUsage = 0xf0
 	Remark1  TransactionAttributeUsage = 0xf1
 	Remark2  TransactionAttributeUsage = 0xf2

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func main() {
 
 	time.Sleep(2 * time.Second)
 	for {
-		fmt.Println("ledger.DefaultLedger.Blockchain.BlockHeight= ", ledger.DefaultLedger.Blockchain.BlockHeight)
+		log.Trace("ledger.DefaultLedger.Blockchain.BlockHeight= ", ledger.DefaultLedger.Blockchain.BlockHeight)
 		time.Sleep(dbft.GenBlockTime)
 	}
 }

--- a/net/httpjsonrpc/sampleTransaction.go
+++ b/net/httpjsonrpc/sampleTransaction.go
@@ -101,12 +101,10 @@ func SignTx(admin *client.Account, tx *transaction.Transaction) {
 
 func SendTx(tx *transaction.Transaction) error {
 	if err := validation.VerifyTransaction(tx); err != nil {
-		log.Warn("Transaction verification failed")
-		return errors.New("Transaction verification failed")
+		log.Error("Transaction verification failed")
 	}
 	if err := validation.VerifyTransactionWithLedger(tx, ledger.DefaultLedger); err != nil {
-		log.Warn("Transaction verification with ledger failed")
-		return errors.New("Transaction verification with ledger failed")
+		log.Error("Transaction verification with ledger failed")
 	}
 	if !node.AppendTxnPool(tx) {
 		log.Warn("Can NOT add the transaction to TxnPool")

--- a/net/node/transactionPool.go
+++ b/net/node/transactionPool.go
@@ -61,7 +61,8 @@ func (txnPool *TXNPool) CleanTxnPool(txs []*transaction.Transaction) error {
 	txsNum := len(txs)
 	txInPoolNum := len(txnPool.list)
 	cleaned := 0
-	for _, tx := range txs {
+	// skip the first bookkeeping transaction
+	for _, tx := range txs[1:] {
 		delete(txnPool.list, tx.Hash())
 		cleaned++
 	}


### PR DESCRIPTION
Sent all entire transactions got from transaction pool other than
transaction hashes in Prepare Request. The first transaction in block 
still be bookkeeping transaction. If non-primary nodes receive
transactions which doesn't exist in local transaction pool then 
do fully transaction verification.

Signed-off-by: Ziyan Zhou <zhouziyan@hotmail.com>