### PR TITLE
bug fixes and code optimizing for RPC interfaces

### DIFF
--- a/net/httpjsonrpc/RPCserver.go
+++ b/net/httpjsonrpc/RPCserver.go
@@ -13,7 +13,6 @@ func StartRPCServer() {
 
 	HandleFunc("getbestblockhash", getBestBlockHash)
 	HandleFunc("getblock", getBlock)
-	HandleFunc("getTxn", getTxn)
 	HandleFunc("getAddrTxn", getAddrTxn)
 	HandleFunc("getblockcount", getBlockCount)
 	HandleFunc("getblockhash", getBlockHash)

--- a/net/httpjsonrpc/TransPayloadToHex.go
+++ b/net/httpjsonrpc/TransPayloadToHex.go
@@ -6,7 +6,6 @@ import (
 	. "DNA/core/contract"
 	. "DNA/core/transaction"
 	"DNA/core/transaction/payload"
-	"DNA/crypto"
 )
 
 type PayloadInfo interface {
@@ -49,11 +48,15 @@ func (a *IssueAssetInfo) Data() []byte {
 	return []byte{0}
 }
 
+type IssuerInfo struct {
+	X, Y string
+}
+
 //implement PayloadInfo define RegisterAssetInfo
 type RegisterAssetInfo struct {
 	Asset      *asset.Asset
 	Amount     Fixed64
-	Issuer     *crypto.PubKey
+	Issuer     IssuerInfo
 	Controller string
 }
 
@@ -98,7 +101,8 @@ func TransPayloadToHex(p Payload) PayloadInfo {
 		obj := new(RegisterAssetInfo)
 		obj.Asset = object.Asset
 		obj.Amount = object.Amount
-		obj.Issuer = object.Issuer
+		obj.Issuer.X = object.Issuer.X.String()
+		obj.Issuer.Y = object.Issuer.Y.String()
 		obj.Controller = ToHexString(object.Controller.ToArray())
 		return obj
 	case *payload.Record:
@@ -109,4 +113,3 @@ func TransPayloadToHex(p Payload) PayloadInfo {
 	}
 	return nil
 }
-

--- a/net/httpjsonrpc/common.go
+++ b/net/httpjsonrpc/common.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	mainMux.m = make(map[string]func(map[string]interface{}) map[string]interface{})
+	mainMux.m = make(map[string]func([]interface{}) map[string]interface{})
 }
 
 //an instance of the multiplexer
@@ -26,7 +26,7 @@ var dBFT *dbft.DbftService
 //multiplexer that keeps track of every function to be called on specific rpc call
 type ServeMux struct {
 	sync.RWMutex
-	m               map[string]func(map[string]interface{}) map[string]interface{}
+	m               map[string]func([]interface{}) map[string]interface{}
 	defaultFunction func(http.ResponseWriter, *http.Request)
 }
 
@@ -108,7 +108,6 @@ type BlockInfo struct {
 type TxInfo struct {
 	Hash string
 	Hex  string
-	//Tx   *tx.Transaction
 	Tx   *Transactions
 }
 
@@ -148,7 +147,7 @@ func RegistDbftService(d *dbft.DbftService) {
 }
 
 //a function to register functions to be called for specific rpc calls
-func HandleFunc(pattern string, handler func(map[string]interface{}) map[string]interface{}) {
+func HandleFunc(pattern string, handler func([]interface{}) map[string]interface{}) {
 	mainMux.Lock()
 	defer mainMux.Unlock()
 	mainMux.m[pattern] = handler
@@ -176,7 +175,7 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	//We must check if there is Request Body to read
+	//check if there is Request Body to read
 	if r.Body == nil {
 		if mainMux.defaultFunction != nil {
 			log.Printf("HTTP JSON RPC Handle - Request body is nil")
@@ -190,45 +189,34 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 
 	//read the body of the request
 	body, err := ioutil.ReadAll(r.Body)
-	//log.Println(r)
-	//log.Println(body)
 	if err != nil {
 		log.Fatalf("HTTP JSON RPC Handle - ioutil.ReadAll: %v", err)
 		return
 	}
 	request := make(map[string]interface{})
-	//unmarshal the request
 	err = json.Unmarshal(body, &request)
 	if err != nil {
 		log.Fatalf("HTTP JSON RPC Handle - json.Unmarshal: %v", err)
 		return
 	}
-	//log.Println(request["method"])
 
 	//get the corresponding function
 	function, ok := mainMux.m[request["method"].(string)]
-
 	if ok {
-		response := function(request)
-		//response from the program is encoded
-		data, err := json.Marshal(response)
+		response := function(request["params"].([]interface{}))
+		data, err := json.Marshal(map[string]interface{}{
+			"jsonpc": "2.0",
+			"result": response["result"],
+			"id":     request["id"],
+		})
 		if err != nil {
 			log.Fatalf("HTTP JSON RPC Handle - json.Marshal: %v", err)
 			return
 		}
-		//result is printed to the output
 		w.Write(data)
-	} else { //if the function does not exist
-		log.Println("HTTP JSON RPC Handle - No function to call for", request["method"])
-
-		//if you don't want to send an error, send something else:
-		// data, err := json.Marshal(map[string]interface{}{
-		//        	"result": "OK!",
-		//        	"error": nil,
-		//        	"id": request["id"],
-		// })
-
-		//an error json is created
+	} else {
+		//if the function does not exist
+		log.Printf("HTTP JSON RPC Handle - No function to call for", request["method"])
 		data, err := json.Marshal(map[string]interface{}{
 			"result": nil,
 			"error": map[string]interface{}{
@@ -246,11 +234,9 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func responsePacking(result interface{}, id interface{}) map[string]interface{} {
+func responsePacking(result interface{}) map[string]interface{} {
 	resp := map[string]interface{}{
-		"Jsonrpc": "2.0",
-		"Result":  result,
-		"Id":      id,
+		"result": result,
 	}
 	return resp
 }

--- a/net/httpjsonrpc/rpcResult.go
+++ b/net/httpjsonrpc/rpcResult.go
@@ -1,0 +1,20 @@
+package httpjsonrpc
+
+var (
+	DnaRpcInvalidHash        = responsePacking("invalid hash")
+	DnaRpcInvalidBlock       = responsePacking("invalid block")
+	DnaRpcInvalidTransaction = responsePacking("invalid transaction")
+	DnaRpcInvalidParameter   = responsePacking("invalid parameter")
+
+	DnaRpcUnknownBlock       = responsePacking("unknown block")
+	DnaRpcUnknownTransaction = responsePacking("unknown transaction")
+
+	DnaRpcNil           = responsePacking(nil)
+	DnaRpcUnsupported   = responsePacking("Unsupported")
+	DnaRpcInternalError = responsePacking("internal error")
+
+	DnaRpcSuccess = responsePacking(true)
+	DnaRpcFailed  = responsePacking(false)
+
+	DnaRpc = responsePacking
+)

--- a/utility/common.go
+++ b/utility/common.go
@@ -41,10 +41,9 @@ type Param struct {
 	NodeState       bool   // node state
 	Tx              string // Transaction test case
 	TxNum           int64  // count of transaction
-	NoSign          bool   // transaction is not signed
 	DebugLevel      int    // transaction is not signed
 	RPCID           int64  // RPC ID, use int64 by default
-	RawTxHash       string // get tx detail info by hash of raw transaction 
+	RawTxHash       string // get tx detail info by hash of raw transaction
 	RawTx           string // send tx to block chain,then transaction encode hex string
 	Flag            bool   // it control RawTxHash display format
 }
@@ -66,7 +65,6 @@ func registerFlags(f *flag.FlagSet) {
 	f.BoolVar(&p.Start, "start", false, "start service")
 	f.StringVar(&p.Tx, "tx", "full", "send sample transaction with different type (full/perf)")
 	f.Int64Var(&p.TxNum, "num", 1, "transaction number")
-	f.BoolVar(&p.NoSign, "nosign", false, "send unsigned transaction")
 	f.BoolVar(&p.Stop, "stop", false, "stop service")
 	f.StringVar(&p.RawTxHash, "rawtxhash", "", "get raw transaction info")
 	f.StringVar(&p.RawTx, "rawtx", "", "send raw transaction")

--- a/utility/test/test.go
+++ b/utility/test/test.go
@@ -9,12 +9,12 @@ import (
 
 var usage = `run sample routines`
 
-var flags = []string{"tx", "num", "nosign"}
+var flags = []string{"tx", "num"}
 
 func testMain(args []string, p utility.Param) (err error) {
 	if txType := p.Tx; txType != "" {
 		resp, err := httpjsonrpc.Call(utility.Address(p.Ip, p.Port), "sendsampletransaction",
-			p.RPCID, []interface{}{p.Tx, p.TxNum, p.NoSign})
+			p.RPCID, []interface{}{p.Tx, p.TxNum})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return err


### PR DESCRIPTION
1. Found bugs when use third-pary tool access RPC interface, fix them and
optimize RPC server. Now id is not an input parameter for registered
functions. Makes these interfaces more friendly, we can use tool which
support JSON to interact with Chain!

2. Remove -nosign flag when sending sample transaction with nodectl
since we always verify it on chain.

3. Add error messages and catching for RPC server, users could get 
more detailed information when they do some ops on chain.