### PR TITLE
fix: override data shared by two array slice in vm\utils\stack.go

### DIFF
--- a/vm/utils/stack.go
+++ b/vm/utils/stack.go
@@ -4,7 +4,6 @@ type RandomAccessStack struct {
 	Element []interface{}
 }
 
-
 func NewRandAccessStack() *RandomAccessStack {
 	var ras RandomAccessStack
 	ras.Element = make([]interface{}, 0)
@@ -17,25 +16,38 @@ func (ras *RandomAccessStack) Count() int {
 
 func (ras *RandomAccessStack) Insert(index int, t interface{}) {
 	l := len(ras.Element)
-	if index > l { return }
-	var array []interface{}
+	if index > l {
+		return
+	}
+	if index == 0 {
+		ras.Element = append(ras.Element, t)
+		return
+	}
+
+	var array = make([]interface{}, 0, l+1)
 	index = l - index
-	array = append(ras.Element[:index], t)
+	array = append(array, ras.Element[:index])
+	array = append(array, t)
 	array = append(array, ras.Element[index:]...)
+
 	ras.Element = array
 }
 
 func (ras *RandomAccessStack) Peek(index int) interface{} {
 	l := len(ras.Element)
-	if index >= l {return nil}
+	if index >= l {
+		return nil
+	}
 	index = l - index
-	return ras.Element[index - 1]
+	return ras.Element[index-1]
 }
 
 func (ras *RandomAccessStack) Remove(index int) interface{} {
 	l := len(ras.Element)
-	if index >= l {return nil}
-	index = l-index
+	if index >= l {
+		return nil
+	}
+	index = l - index
 	e := ras.Element[index-1]
 	var si []interface{}
 	si = append(ras.Element[:index-1], ras.Element[index:]...)
@@ -45,7 +57,9 @@ func (ras *RandomAccessStack) Remove(index int) interface{} {
 
 func (ras *RandomAccessStack) Set(index int, t interface{}) {
 	l := len(ras.Element)
-	if index >= l {return}
+	if index >= l {
+		return
+	}
 	ras.Element[index] = t
 }
 

--- a/vm/utils/stack_test.go
+++ b/vm/utils/stack_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func assertEqual(t *testing.T, exp, got interface{}) {
+	res := reflect.DeepEqual(exp, got)
+	if res == false {
+		err := fmt.Sprint("Error: expect ", exp, " got ", got)
+
+		_, file, line, _ := runtime.Caller(1)
+		t.Errorf("%s:%d %s", file, line, err)
+	}
+}
+
+func TestRandomAccessStack(t *testing.T) {
+
+	var stack = NewRandAccessStack()
+	assertEqual(t, stack.Count(), 0)
+	for i := 0; i < 10; i++ {
+		stack.Push(i)
+		assertEqual(t, stack.Count(), i+1)
+	}
+
+	for i := 9; i >= 0; i-- {
+		elem := stack.Pop()
+		assertEqual(t, elem.(int), i)
+	}
+	assertEqual(t, stack.Count(), 0)
+
+	for i := 0; i < 10; i++ {
+		stack.Insert(i, i)
+		assertEqual(t, stack.Peek(i).(int), i)
+		assertEqual(t, stack.Peek(0).(int), 0)
+	}
+
+	for i := 0; i < 10; i++ {
+		stack.Set(i, i+1)
+		assertEqual(t, stack.Peek(i).(int), i+1)
+	}
+
+}


### PR DESCRIPTION
got confirmed with the maintainer of vm.
bug fixed the issue of the RandomAccessStack struct function: Insert .
cause of override data shared by two array slice.

Signed-off-by: lzc <laizhichao@onchain.com>