### PR TITLE
Get connected remote node version by using nodectl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,12 @@ GOFMT=gofmt
 GC=go build
 VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
 Minversion := $(shell date)
-BUILD_PAR = -ldflags "-X main.Version=$(VERSION)" #-race
+BUILD_NODE_PAR = -ldflags "-X DNA/common/config.Version=$(VERSION)" #-race
+BUILD_NODECTL_PAR = -ldflags "-X DNA/cli.Version=$(VERSION)"
 
 all:
-	$(GC)  $(BUILD_PAR) -o node main.go
-	$(GC)  $(BUILD_PAR) nodectl.go
+	$(GC)  $(BUILD_NODE_PAR) -o node main.go
+	$(GC)  $(BUILD_NODECTL_PAR) nodectl.go
 
 format:
 	$(GOFMT) -w main.go

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -19,6 +19,8 @@ import (
 	"github.com/urfave/cli"
 )
 
+var Version string
+
 func init() {
 	var path string = "./Log/"
 	log.CreatePrintLog(path)
@@ -28,7 +30,7 @@ func init() {
 
 	app := cli.NewApp()
 	app.Name = "nodectl"
-	app.Version = "1.0.1"
+	app.Version = Version
 	app.HelpName = "nodectl"
 	app.Usage = "command line tool for DNA blockchain"
 	app.UsageText = "nodectl [global options] command [command options] [args]"

--- a/cli/info/info.go
+++ b/cli/info/info.go
@@ -23,6 +23,7 @@ func infoAction(c *cli.Context) (err error) {
 	connections := c.Bool("connections")
 	neighbor := c.Bool("neighbor")
 	state := c.Bool("state")
+	version := c.Bool("nodeversion")
 
 	var resp []byte
 	var output [][]byte
@@ -97,6 +98,16 @@ func infoAction(c *cli.Context) (err error) {
 		}
 		output = append(output, resp)
 	}
+
+	if version {
+		resp, err = httpjsonrpc.Call(Address(), "getversion", 0, []interface{}{})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+		output = append(output, resp)
+
+	}
 	for _, v := range output {
 		FormatOutput(v)
 	}
@@ -143,6 +154,10 @@ func NewCommand() *cli.Command {
 			cli.BoolFlag{
 				Name:  "state, s",
 				Usage: "current node state",
+			},
+			cli.BoolFlag{
+				Name:  "nodeversion, v",
+				Usage: "version of connected remote node",
 			},
 		},
 		Action: infoAction,

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -14,9 +14,11 @@ const (
 	DefaultConfigFilename = "./config.json"
 )
 
+var Version string
+
 type Configuration struct {
 	Magic           int64    `json:"Magic"`
-	Version		int      `json:"Version"`
+	Version         int      `json:"Version"`
 	SeedList        []string `json:"SeedList"`
 	HttpJsonPort    int      `json:"HttpJsonPort"`
 	HttpLocalPort   int      `json:"HttpLocalPort"`

--- a/main.go
+++ b/main.go
@@ -24,8 +24,6 @@ const (
 	DefaultMultiCoreNum  = 4
 )
 
-var Version string
-
 func init() {
 	var path string = "./Log/"
 	log.CreatePrintLog(path)
@@ -67,7 +65,7 @@ func InitBlockChain() ledger.Blockchain {
 }
 
 func main() {
-	fmt.Printf("Node version: %s\n", Version)
+	fmt.Printf("Node version: %s\n", config.Version)
 	fmt.Println("//**************************************************************************")
 	fmt.Println("//*** 0. Client open                                                     ***")
 	fmt.Println("//**************************************************************************")

--- a/net/httpjsonrpc/RPCserver.go
+++ b/net/httpjsonrpc/RPCserver.go
@@ -21,6 +21,7 @@ func StartRPCServer() {
 	HandleFunc("getrawtransaction", getRawTransaction)
 	HandleFunc("sendrawtransaction", sendRawTransaction)
 	HandleFunc("submitblock", submitBlock)
+	HandleFunc("getversion", getVersion)
 
 	err := http.ListenAndServe(":"+strconv.Itoa(Parameters.HttpJsonPort), nil)
 	if err != nil {

--- a/net/httpjsonrpc/interfaces.go
+++ b/net/httpjsonrpc/interfaces.go
@@ -3,6 +3,7 @@ package httpjsonrpc
 import (
 	"DNA/client"
 	. "DNA/common"
+	"DNA/common/config"
 	"DNA/common/log"
 	"DNA/core/ledger"
 	tx "DNA/core/transaction"
@@ -484,4 +485,8 @@ func setDebugInfo(params []interface{}) map[string]interface{} {
 		return DnaRpcInvalidParameter
 	}
 	return DnaRpcSuccess
+}
+
+func getVersion(params []interface{}) map[string]interface{} {
+	return DnaRpc(config.Version)
 }


### PR DESCRIPTION
1. Add an --nodeversion(-v) option for `nodectl info` subcommand
2. Add a RPC interface `getversion`

Using command line
$ nodectl info --nodeversion (-v)
to show connected remote node version