### PR TITLE
Fix bugs in client.go and log.go

### DIFF
--- a/client/account_test.go
+++ b/client/account_test.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"testing"
+	"DNA/crypto"
+	"os"
+	"path"
+	"fmt"
+)
+
+func TestClient(t *testing.T) {
+	t.Log("created client start!")
+	crypto.SetAlg(crypto.P256R1)
+	dir := "./data/"
+	err := os.MkdirAll(dir, 0777)
+	if err != nil {
+		t.Log("create dir ", dir, " error: ", err)
+	}else {
+		t.Log("create dir ", dir, " success!")
+	}
+	for i:=0;i<10000;i++ {
+		p := path.Join(dir, fmt.Sprintf("wallet%d.txt", i))
+		fmt.Println("client path", p)
+		CreateClient(p, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06})
+	}
+}

--- a/client/account_test.go
+++ b/client/account_test.go
@@ -1,11 +1,11 @@
 package client
 
 import (
-	"testing"
 	"DNA/crypto"
+	"fmt"
 	"os"
 	"path"
-	"fmt"
+	"testing"
 )
 
 func TestClient(t *testing.T) {
@@ -15,12 +15,12 @@ func TestClient(t *testing.T) {
 	err := os.MkdirAll(dir, 0777)
 	if err != nil {
 		t.Log("create dir ", dir, " error: ", err)
-	}else {
+	} else {
 		t.Log("create dir ", dir, " success!")
 	}
-	for i:=0;i<10000;i++ {
+	for i := 0; i < 10000; i++ {
 		p := path.Join(dir, fmt.Sprintf("wallet%d.txt", i))
 		fmt.Println("client path", p)
-		CreateClient(p, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06})
+		CreateClient(p, []byte("\x12\x34\x56"))
 	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -390,7 +390,6 @@ func (cl *ClientImpl) DecryptPrivateKey(prikey []byte) ([]byte, error) {
 }
 
 func (cl *ClientImpl) SaveAccount(ac *Account) error {
-
 	decryptedPrivateKey := make([]byte, 96)
 	temp, err := ac.PublicKey.EncodePoint(false)
 	if err != nil {
@@ -401,7 +400,7 @@ func (cl *ClientImpl) SaveAccount(ac *Account) error {
 	}
 
 	for i := len(ac.PrivateKey) - 1; i >= 0; i-- {
-		decryptedPrivateKey[64+i] = ac.PrivateKey[i]
+		decryptedPrivateKey[96+i-len(ac.PrivateKey)] = ac.PrivateKey[i]
 	}
 
 	encryptedPrivateKey, err := cl.EncryptPrivateKey(decryptedPrivateKey)

--- a/client/client.go
+++ b/client/client.go
@@ -400,7 +400,7 @@ func (cl *ClientImpl) SaveAccount(ac *Account) error {
 		decryptedPrivateKey[i-1] = temp[i]
 	}
 
-	for i := 0; i < 32; i++ {
+	for i := len(ac.PrivateKey) - 1; i >= 0; i-- {
 		decryptedPrivateKey[64+i] = ac.PrivateKey[i]
 	}
 

--- a/common/log/log.go
+++ b/common/log/log.go
@@ -184,27 +184,19 @@ func Debug(a ...interface{}) {
 }
 
 func Info(a ...interface{}) {
-	if Log != nil {
-		Log.Info(fmt.Sprint(a...))
-	}
+	Log.Info(fmt.Sprint(a...))
 }
 
 func Warn(a ...interface{}) {
-	if Log != nil {
-		Log.Warn(fmt.Sprint(a...))
-	}
+	Log.Warn(fmt.Sprint(a...))
 }
 
 func Error(a ...interface{}) {
-	if Log != nil {
-		Log.Error(fmt.Sprint(a...))
-	}
+	Log.Error(fmt.Sprint(a...))
 }
 
 func Fatal(a ...interface{}) {
-	if Log != nil {
-		Log.Fatal(fmt.Sprint(a...))
-	}
+	Log.Fatal(fmt.Sprint(a...))
 }
 
 func FileOpen(path string) (*os.File, error) {

--- a/common/log/log.go
+++ b/common/log/log.go
@@ -184,19 +184,27 @@ func Debug(a ...interface{}) {
 }
 
 func Info(a ...interface{}) {
-	Log.Info(fmt.Sprint(a...))
+	if Log != nil {
+		Log.Info(fmt.Sprint(a...))
+	}
 }
 
 func Warn(a ...interface{}) {
-	Log.Warn(fmt.Sprint(a...))
+	if Log != nil {
+		Log.Warn(fmt.Sprint(a...))
+	}
 }
 
 func Error(a ...interface{}) {
-	Log.Error(fmt.Sprint(a...))
+	if Log != nil {
+		Log.Error(fmt.Sprint(a...))
+	}
 }
 
 func Fatal(a ...interface{}) {
-	Log.Fatal(fmt.Sprint(a...))
+	if Log != nil {
+		Log.Fatal(fmt.Sprint(a...))
+	}
 }
 
 func FileOpen(path string) (*os.File, error) {

--- a/common/log/log_test.go
+++ b/common/log/log_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 )
 
-
 func TestDebugPrint(t *testing.T) {
 	CreatePrintLog("./")
 	Debug("debug testing")
@@ -17,7 +16,7 @@ func TestInfoPrint(t *testing.T) {
 
 func TestWarningPrint(t *testing.T) {
 	CreatePrintLog("./")
-	Warning("Warning testing")
+	Warn("Warning testing")
 }
 
 func TestErrorPrint(t *testing.T) {


### PR DESCRIPTION
1. Fix the out of range bug in client/client.go:SaveAccount when the length of private key is less than 32 bytes(the leading byte(s) is 0).
2. Check the pointer "Log" before used in Info, Warn, Error and Fatal.