### PR TITLE
Add support for creating ContractContext without programhash and fix

### DIFF
--- a/cli/asset/asset.go
+++ b/cli/asset/asset.go
@@ -83,7 +83,7 @@ func signTransaction(signer *client.Account, tx *transaction.Transaction) error 
 		return err
 	}
 	transactionContractContext := newContractContextWithoutProgramHashes(tx)
-	if err := transactionContractContext.AddContract(transactionContract, signer.PubKey(), signature); err != nil {
+	if err := transactionContractContext.AddContract(transactionContract, signer.PubKey(), signature, false); err != nil {
 		fmt.Println("AddContract failed")
 		return err
 	}
@@ -272,10 +272,10 @@ func assetAction(c *cli.Context) error {
 		} else if transfer {
 			txHex, err = makeTransferTransaction(admin, to, asset, Fixed64(value))
 		}
-		if err != nil {
-			fmt.Println(err)
-			return nil
-		}
+	}
+	if err != nil {
+		fmt.Println(err)
+		return nil
 	}
 	resp, err := httpjsonrpc.Call(Address(), "sendrawtransaction", 0, []interface{}{txHex})
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -346,7 +346,7 @@ func (cl *ClientImpl) Sign(context *ct.ContractContext) bool {
 		if err != nil {
 			return fSuccess
 		}
-		err = context.AddContract(contract, account.PublicKey, signature)
+		err = context.AddContract(contract, account.PublicKey, signature, true)
 
 		if err != nil {
 			fSuccess = false

--- a/consensus/dbft/dbftService.go
+++ b/consensus/dbft/dbftService.go
@@ -141,7 +141,7 @@ func (ds *DbftService) CheckSignatures() error {
 		cxt := ct.NewContractContext(block)
 		for i, j := 0, 0; i < len(ds.context.BookKeepers) && j < ds.context.M(); i++ {
 			if ds.context.Signatures[i] != nil {
-				err := cxt.AddContract(contract, ds.context.BookKeepers[i], ds.context.Signatures[i])
+				err := cxt.AddContract(contract, ds.context.BookKeepers[i], ds.context.Signatures[i], true)
 				if err != nil {
 					log.Error("[CheckSignatures] Multi-sign add contract error:", err.Error())
 					return NewDetailErr(err, ErrNoCode, "[DbftService], CheckSignatures AddContract failed.")

--- a/net/httpjsonrpc/sampleTransaction.go
+++ b/net/httpjsonrpc/sampleTransaction.go
@@ -31,6 +31,6 @@ func SignTx(admin *client.Account, tx *transaction.Transaction) {
 	}
 	transactionContract, _ := contract.CreateSignatureContract(admin.PublicKey)
 	transactionContractContext := contract.NewContractContext(tx)
-	transactionContractContext.AddContract(transactionContract, admin.PublicKey, signdate)
+	transactionContractContext.AddContract(transactionContract, admin.PublicKey, signdate, true)
 	tx.SetPrograms(transactionContractContext.GetPrograms())
 }


### PR DESCRIPTION
Add a bool parameter for AddContract Function.
If the caller is basing on a full node (has full block data in local
database) the newly added parameter 'isFullNode' should be set to true,
since caller can get necessary program hash from local database.
Otherwise, if caller is working on a light node, 'isFullNode' should be
set to false, because can't get necessary program hash. At this time,
the caller might have to construct a ContractContext without programhash.

This patch also fixes panic bug while sending record transaction from
full node side.

Signed-off-by: Ziyan Zhou <zhouziyan@hotmail.com>