### PR TITLE
fix SyncBlk issue

### DIFF
--- a/net/node/infoUpdate.go
+++ b/net/node/infoUpdate.go
@@ -1,8 +1,8 @@
 package node
 
 import (
-	"DNA/common/log"
 	"DNA/common/config"
+	"DNA/common/log"
 	"DNA/core/ledger"
 	. "DNA/net/message"
 	. "DNA/net/protocol"
@@ -41,6 +41,7 @@ func (node *node) SyncBlk() {
 	var i uint32
 	noders := node.local.GetNeighborNoder()
 	for _, n := range noders {
+		n.RemoveFlightHeightLessThan(currentBlkHeight)
 		count := MAXREQBLKONCE - uint32(n.GetFlightHeightCnt())
 		dValue = int32(headerHeight - currentBlkHeight - reqCnt)
 		for i = 1; i <= count && dValue >= 0; i++ {
@@ -90,7 +91,7 @@ func (node node) ReqNeighborList() {
 }
 
 func (node node) ConnectSeeds() {
-	if (node.nbrNodes.GetConnectionCnt() == 0) {
+	if node.nbrNodes.GetConnectionCnt() == 0 {
 		seedNodes := config.Parameters.SeedList
 		for _, nodeAddr := range seedNodes {
 			go node.Connect(nodeAddr)

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -359,6 +359,22 @@ func (node node) GetFlightHeightCnt() int {
 	return len(node.flightHeights)
 }
 
+func (node *node) RemoveFlightHeightLessThan(h uint32) {
+	heights := node.flightHeights
+	p := len(heights)
+	i := 0
+
+	for i < p {
+		if heights[i] < h {
+			p--
+			heights[p], heights[i] = heights[i], heights[p]
+		} else {
+			i++
+		}
+	}
+	node.flightHeights = heights[:p]
+}
+
 func (node *node) RemoveFlightHeight(height uint32) {
 	log.Debug("height is ", height)
 	for _, h := range node.flightHeights {

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -114,6 +114,7 @@ type Noder interface {
 	GetNbrNodeCnt() uint32
 	StoreFlightHeight(height uint32)
 	GetFlightHeightCnt() int
+	RemoveFlightHeightLessThan(height uint32)
 	RemoveFlightHeight(height uint32)
 	GetLastRXTime() time.Time
 	SetHeight(height uint64)


### PR DESCRIPTION
flightHeight array in each peer node may be filled with outdated requests forever.
So before send Block Request message, remove request whose height is less than current BlockHeight in each peer node's flightHeight array.

Signed-off-by: lzc <laizhichao@onchain.com>