### PR TITLE
support for dynamic bookkeeper list configuration

### DIFF
--- a/cli/test/test.go
+++ b/cli/test/test.go
@@ -17,8 +17,16 @@ func testAction(c *cli.Context) (err error) {
 	}
 	txnType := c.String("tx")
 	txnNum := c.Int("num")
-	if txnType != "" {
+	action := c.String("action")
+	if txnType == "perf" {
 		resp, err := httpjsonrpc.Call(Address(), "sendsampletransaction", 0, []interface{}{txnType, txnNum})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+		FormatOutput(resp)
+	} else if txnType == "bookkeeper" {
+		resp, err := httpjsonrpc.Call(Address(), "sendsampletransaction", 0, []interface{}{txnType, txnNum, action})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return err
@@ -37,13 +45,18 @@ func NewCommand() *cli.Command {
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "tx, t",
-				Usage: "send sample transaction",
+				Usage: "send sample transaction: perf or bookkeeper",
 				Value: "perf",
 			},
 			cli.IntFlag{
 				Name:  "num, n",
 				Usage: "sample transaction numbers",
 				Value: 1,
+			},
+			cli.StringFlag{
+				Name:  "action, a",
+				Usage: "action to modify bookkepper list: add or sub",
+				Value: "add",
 			},
 		},
 		Action: testAction,

--- a/core/ledger/blockchain.go
+++ b/core/ledger/blockchain.go
@@ -23,7 +23,7 @@ func NewBlockchain(height uint32) *Blockchain {
 	}
 }
 
-func NewBlockchainWithGenesisBlock() (*Blockchain, error) {
+func NewBlockchainWithGenesisBlock( defaultBookKeeper []*crypto.PubKey ) (*Blockchain, error) {
 	genesisBlock, err := GenesisBlockInit()
 	if err != nil {
 		return nil, NewDetailErr(err, ErrNoCode, "[Blockchain], NewBlockchainWithGenesisBlock failed.")
@@ -32,7 +32,7 @@ func NewBlockchainWithGenesisBlock() (*Blockchain, error) {
 	hashx := genesisBlock.Hash()
 	genesisBlock.hash = &hashx
 
-	height, err := DefaultLedger.Store.InitLedgerStoreWithGenesisBlock(genesisBlock)
+	height, err := DefaultLedger.Store.InitLedgerStoreWithGenesisBlock( genesisBlock, defaultBookKeeper )
 	if err != nil {
 		return nil, NewDetailErr(err, ErrNoCode, "[Blockchain], InitLevelDBStoreWithGenesisBlock failed.")
 	}

--- a/core/ledger/ledgerStore.go
+++ b/core/ledger/ledgerStore.go
@@ -4,6 +4,7 @@ import (
 	. "DNA/common"
 	. "DNA/core/asset"
 	tx "DNA/core/transaction"
+	"DNA/crypto"
 )
 
 // ILedgerStore provides func with store package.
@@ -31,7 +32,8 @@ type ILedgerStore interface {
 	GetHeight() uint32
 	GetHeaderHashByHeight(height uint32) Uint256
 
-	InitLedgerStoreWithGenesisBlock(genesisblock *Block) (uint32, error)
+	GetBookKeeperList() ([]*crypto.PubKey, []*crypto.PubKey, error)
+	InitLedgerStoreWithGenesisBlock(genesisblock *Block, defaultBookKeeper []*crypto.PubKey) (uint32, error)
 
 	GetQuantityIssued(assetid Uint256) (Fixed64, error)
 

--- a/core/store/ChainStore/ChainStore.go
+++ b/core/store/ChainStore/ChainStore.go
@@ -12,11 +12,14 @@ import (
 	tx "DNA/core/transaction"
 	"DNA/core/transaction/payload"
 	"DNA/core/validation"
+	"DNA/crypto"
 	. "DNA/errors"
 	"DNA/events"
 	"bytes"
 	"errors"
 	"fmt"
+	"math/big"
+	"sort"
 	"sync"
 )
 
@@ -68,7 +71,7 @@ func NewChainStore(file string) (*ChainStore, error) {
 	}, nil
 }
 
-func (bd *ChainStore) InitLedgerStoreWithGenesisBlock(genesisBlock *Block) (uint32, error) {
+func (bd *ChainStore) InitLedgerStoreWithGenesisBlock(genesisBlock *Block, defaultBookKeeper []*crypto.PubKey) (uint32, error) {
 
 	hash := genesisBlock.Hash()
 	bd.headerIndex[0] = hash
@@ -194,6 +197,33 @@ func (bd *ChainStore) InitLedgerStoreWithGenesisBlock(genesisBlock *Block) (uint
 		if err != nil {
 			return 0, err
 		}
+
+		///////////////////////////////////////////////////
+		// process defaultBookKeeper
+		///////////////////////////////////////////////////
+		// sort defaultBookKeeper
+		sort.Sort(crypto.PubKeySlice(defaultBookKeeper))
+
+		// currBookKeeper key
+		bkListKey := bytes.NewBuffer(nil)
+		bkListKey.WriteByte(byte(SYS_CurrentBookKeeper))
+
+		// currBookKeeper value
+		bkListValue := bytes.NewBuffer(nil)
+		serialization.WriteUint8(bkListValue, uint8(len(defaultBookKeeper)))
+		for k := 0; k < len(defaultBookKeeper); k++ {
+			defaultBookKeeper[k].Serialize(bkListValue)
+		}
+
+		// nextBookKeeper value
+		serialization.WriteUint8(bkListValue, uint8(len(defaultBookKeeper)))
+		for k := 0; k < len(defaultBookKeeper); k++ {
+			defaultBookKeeper[k].Serialize(bkListValue)
+		}
+
+		// defaultBookKeeper put value
+		bd.st.Put(bkListKey.Bytes(), bkListValue.Bytes())
+		///////////////////////////////////////////////////
 
 		// persist genesis block
 		bd.persist(genesisBlock)
@@ -562,6 +592,51 @@ func (bd *ChainStore) GetBlock(hash Uint256) (*Block, error) {
 	return b, nil
 }
 
+func (self *ChainStore) GetBookKeeperList() ([]*crypto.PubKey, []*crypto.PubKey, error) {
+	prefix := []byte{byte(SYS_CurrentBookKeeper)}
+	bkListValue, err_get := self.st.Get(prefix)
+	if err_get != nil {
+		return nil, nil, err_get
+	}
+
+	r := bytes.NewReader(bkListValue)
+
+	// first 1 bytes is length of list
+	currCount, err := serialization.ReadUint8(r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var currBookKeeper = make([]*crypto.PubKey, currCount)
+	for i := uint8(0); i < currCount; i++ {
+		bk := new(crypto.PubKey)
+		err := bk.DeSerialize(r)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		currBookKeeper[i] = bk
+	}
+
+	nextCount, err := serialization.ReadUint8(r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var nextBookKeeper = make([]*crypto.PubKey, nextCount)
+	for i := uint8(0); i < nextCount; i++ {
+		bk := new(crypto.PubKey)
+		err := bk.DeSerialize(r)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		nextBookKeeper[i] = bk
+	}
+
+	return currBookKeeper, nextBookKeeper, nil
+}
+
 func (bd *ChainStore) persist(b *Block) error {
 	unspents := make(map[Uint256][]uint16)
 	quantities := make(map[Uint256]Fixed64)
@@ -621,6 +696,29 @@ func (bd *ChainStore) persist(b *Block) error {
 	hashValue.Serialize(hashWriter)
 	log.Debug(fmt.Sprintf("DATA_BlockHash table value: %x\n", hashValue))
 
+	needUpdateBookKeeper := false
+	currBookKeeper, nextBookKeeper, err := bd.GetBookKeeperList()
+	// update current BookKeeperList
+	if len(currBookKeeper) != len(nextBookKeeper) {
+		needUpdateBookKeeper = true
+	} else {
+		for i, _ := range currBookKeeper {
+			if currBookKeeper[i].X.Cmp(nextBookKeeper[i].X) != 0 ||
+				currBookKeeper[i].Y.Cmp(nextBookKeeper[i].Y) != 0 {
+				needUpdateBookKeeper = true
+				break
+			}
+		}
+	}
+	if needUpdateBookKeeper {
+		currBookKeeper = make([]*crypto.PubKey, len(nextBookKeeper))
+		for i := 0; i < len(nextBookKeeper); i++ {
+			currBookKeeper[i] = new(crypto.PubKey)
+			currBookKeeper[i].X = new(big.Int).Set(nextBookKeeper[i].X)
+			currBookKeeper[i].Y = new(big.Int).Set(nextBookKeeper[i].Y)
+		}
+	}
+
 	// BATCH PUT VALUE
 	bd.st.BatchPut(bhash.Bytes(), hashWriter.Bytes())
 
@@ -634,6 +732,7 @@ func (bd *ChainStore) persist(b *Block) error {
 			b.Transactions[i].TxType == tx.IssueAsset ||
 			b.Transactions[i].TxType == tx.TransferAsset ||
 			b.Transactions[i].TxType == tx.Record ||
+			b.Transactions[i].TxType == tx.BookKeeper ||
 			b.Transactions[i].TxType == tx.PrivacyPayload ||
 			b.Transactions[i].TxType == tx.BookKeeping {
 			err = bd.SaveTransaction(b.Transactions[i], b.Blockdata.Height)
@@ -695,7 +794,70 @@ func (bd *ChainStore) persist(b *Block) error {
 			}
 		}
 
+		// bookkeeper
+		if b.Transactions[i].TxType == tx.BookKeeper {
+			bk := b.Transactions[i].Payload.(*payload.BookKeeper)
+
+			switch bk.Action {
+			case payload.BookKeeperAction_ADD:
+				findflag := false
+				for k := 0; k < len(nextBookKeeper); k++ {
+					if bk.PubKey.X.Cmp(nextBookKeeper[k].X) == 0 && bk.PubKey.Y.Cmp(nextBookKeeper[k].Y) == 0 {
+						findflag = true
+						break
+					}
+				}
+
+				if !findflag {
+					needUpdateBookKeeper = true
+					nextBookKeeper = append(nextBookKeeper, bk.PubKey)
+					sort.Sort(crypto.PubKeySlice(nextBookKeeper))
+				}
+			case payload.BookKeeperAction_SUB:
+				ind := -1
+				for k := 0; k < len(nextBookKeeper); k++ {
+					if bk.PubKey.X.Cmp(nextBookKeeper[k].X) == 0 && bk.PubKey.Y.Cmp(nextBookKeeper[k].Y) == 0 {
+						ind = k
+						break
+					}
+				}
+
+				if ind != -1 {
+					needUpdateBookKeeper = true
+					// already sorted
+					nextBookKeeper = append(nextBookKeeper[:ind], nextBookKeeper[ind+1:]...)
+				}
+			}
+
+		}
+
 	}
+
+	if needUpdateBookKeeper {
+		//bookKeeper key
+		bkListKey := bytes.NewBuffer(nil)
+		bkListKey.WriteByte(byte(SYS_CurrentBookKeeper))
+
+		//bookKeeper value
+		bkListValue := bytes.NewBuffer(nil)
+
+		serialization.WriteUint8(bkListValue, uint8(len(currBookKeeper)))
+		for k := 0; k < len(currBookKeeper); k++ {
+			currBookKeeper[k].Serialize(bkListValue)
+		}
+
+		serialization.WriteUint8(bkListValue, uint8(len(nextBookKeeper)))
+		for k := 0; k < len(nextBookKeeper); k++ {
+			nextBookKeeper[k].Serialize(bkListValue)
+		}
+
+		// BookKeeper put value
+		bd.st.BatchPut(bkListKey.Bytes(), bkListValue.Bytes())
+
+		///////////////////////////////////////////////////////
+	}
+	///////////////////////////////////////////////////////
+	//*/
 
 	// batch put the unspents
 	for txhash, value := range unspents {
@@ -748,6 +910,7 @@ func (bd *ChainStore) persist(b *Block) error {
 	bd.st.BatchPut(currentBlockKey.Bytes(), currentBlock.Bytes())
 
 	err = bd.st.BatchCommit()
+
 	if err != nil {
 		return err
 	}

--- a/core/store/ChainStore/DataEntryPrefix.go
+++ b/core/store/ChainStore/DataEntryPrefix.go
@@ -24,6 +24,7 @@ const (
 	//SYSTEM
 	SYS_CurrentBlock  DataEntryPrefix = 0x40
 	SYS_CurrentHeader DataEntryPrefix = 0x41
+	SYS_CurrentBookKeeper DataEntryPrefix = 0x42
 
 	//CONFIG
 	CFG_Version DataEntryPrefix = 0xf0

--- a/core/transaction/TransactionBuilder.go
+++ b/core/transaction/TransactionBuilder.go
@@ -32,6 +32,29 @@ func NewRegisterAssetTransaction(asset *asset.Asset, amount common.Fixed64, issu
 	}, nil
 }
 
+//initial a new transaction with asset registration payload
+func NewBookKeeperTransaction(pubKey *crypto.PubKey, isAdd bool, cert []byte) (*Transaction, error) {
+
+	bookKeeperPayload := &payload.BookKeeper{
+		PubKey: pubKey,
+		Action: payload.BookKeeperAction_SUB,
+		Cert:   cert,
+	}
+
+	if isAdd {
+		bookKeeperPayload.Action = payload.BookKeeperAction_ADD
+	}
+
+	return &Transaction{
+		TxType:        BookKeeper,
+		Payload:       bookKeeperPayload,
+		UTXOInputs:    []*UTXOTxInput{},
+		BalanceInputs: []*BalanceTxInput{},
+		Attributes:    []*TxAttribute{},
+		Programs:      []*program.Program{},
+	}, nil
+}
+
 func NewIssueAssetTransaction(outputs []*TxOutput) (*Transaction, error) {
 
 	assetRegPayload := &payload.IssueAsset{}

--- a/core/transaction/payload/BookKeeper.go
+++ b/core/transaction/payload/BookKeeper.go
@@ -1,0 +1,57 @@
+package payload
+
+import (
+	"DNA/common/serialization"
+	"DNA/crypto"
+	. "DNA/errors"
+	"bytes"
+	"io"
+)
+
+type BookKeeperAction byte
+
+const (
+	BookKeeperAction_ADD BookKeeperAction = 0
+	BookKeeperAction_SUB BookKeeperAction = 1
+)
+
+type BookKeeper struct {
+	PubKey *crypto.PubKey
+	Action BookKeeperAction
+	Cert   []byte
+}
+
+func (self *BookKeeper) Data() []byte {
+	var buf bytes.Buffer
+	self.PubKey.Serialize(&buf)
+	buf.WriteByte(byte(self.Action))
+	serialization.WriteVarBytes(&buf, self.Cert)
+
+	return buf.Bytes()
+}
+
+func (self *BookKeeper) Serialize(w io.Writer) error {
+	_, err := w.Write(self.Data())
+
+	return err
+}
+
+func (self *BookKeeper) Deserialize(r io.Reader) error {
+	self.PubKey = new(crypto.PubKey)
+	err := self.PubKey.DeSerialize(r)
+	if err != nil {
+		return NewDetailErr(err, ErrNoCode, "[BookKeeper], PubKey Deserialize failed.")
+	}
+	var p [1]byte
+	n, err := r.Read(p[:])
+	if n == 0 {
+		return NewDetailErr(err, ErrNoCode, "[BookKeeper], Action Deserialize failed.")
+	}
+	self.Action = BookKeeperAction(p[0])
+	self.Cert, err = serialization.ReadVarBytes(r)
+	if err != nil {
+		return NewDetailErr(err, ErrNoCode, "[BookKeeper], Cert Deserialize failed.")
+	}
+
+	return nil
+}

--- a/core/transaction/transaction.go
+++ b/core/transaction/transaction.go
@@ -21,12 +21,13 @@ import (
 type TransactionType byte
 
 const (
-	BookKeeping    TransactionType = 0x00
-	RegisterAsset  TransactionType = 0x40
-	IssueAsset     TransactionType = 0x01
-	TransferAsset  TransactionType = 0x10
-	Record         TransactionType = 0x11
-	DeployCode     TransactionType = 0xd0
+	BookKeeping   TransactionType = 0x00
+	BookKeeper    TransactionType = 0x02
+	RegisterAsset TransactionType = 0x40
+	IssueAsset    TransactionType = 0x01
+	TransferAsset TransactionType = 0x10
+	Record        TransactionType = 0x11
+	DeployCode    TransactionType = 0xd0
 	PrivacyPayload TransactionType = 0x20
 )
 
@@ -191,6 +192,8 @@ func (tx *Transaction) DeserializeUnsignedWithoutType(r io.Reader) error {
 		tx.Payload = new(payload.BookKeeping)
 	} else if tx.TxType == Record {
 		tx.Payload = new(payload.Record)
+	} else if tx.TxType == BookKeeper {
+		tx.Payload = new(payload.BookKeeper)
 	} else if tx.TxType == PrivacyPayload {
 		tx.Payload = new(payload.PrivacyPayload)
 	}
@@ -310,6 +313,7 @@ func (tx *Transaction) GetProgramHashes() ([]Uint160, error) {
 		}
 	case TransferAsset:
 	case Record:
+	case BookKeeper:
 	case PrivacyPayload:
 		issuer := tx.Payload.(*payload.PrivacyPayload).EncryptAttr.(*payload.EcdhAes256).FromPubkey
 		signatureRedeemScript, err := contract.CreateSignatureRedeemScript(issuer)

--- a/core/validation/txValidator.go
+++ b/core/validation/txValidator.go
@@ -34,6 +34,10 @@ func VerifyTransaction(Tx *tx.Transaction) error {
 		return err
 	}
 
+	if err := CheckTransactionPayload(Tx); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -207,4 +211,17 @@ func CheckTransactionContracts(Tx *tx.Transaction) error {
 	} else {
 		return err
 	}
+}
+
+func CheckTransactionPayload(Tx *tx.Transaction) error {
+
+	switch pld := Tx.Payload.(type) {
+	case *payload.BookKeeper:
+		//Todo: validate bookKeeper Cert
+		_ = pld.Cert
+		return nil
+	default:
+		return nil
+	}
+
 }

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 	ledger.StandbyBookKeepers = account.GetBookKeepers()
 
 	log.Info("3. BlockChain init")
-	blockChain, err = ledger.NewBlockchainWithGenesisBlock()
+	blockChain, err = ledger.NewBlockchainWithGenesisBlock(ledger.StandbyBookKeepers)
 	if err != nil {
 		log.Error(err, "  BlockChain generate failed")
 		goto ERROR

--- a/net/httpjsonrpc/TransPayloadToHex.go
+++ b/net/httpjsonrpc/TransPayloadToHex.go
@@ -96,6 +96,7 @@ func (a *PrivacyPayloadInfo) Data() []byte {
 func TransPayloadToHex(p Payload) PayloadInfo {
 	switch object := p.(type) {
 	case *payload.BookKeeping:
+	case *payload.BookKeeper:
 	case *payload.IssueAsset:
 	case *payload.TransferAsset:
 	case *payload.DeployCode:

--- a/net/httpjsonrpc/interfaces.go
+++ b/net/httpjsonrpc/interfaces.go
@@ -491,14 +491,14 @@ func sendSampleTransaction(params []interface{}) map[string]interface{} {
 			return DnaRpcInvalidParameter
 		}
 
-		walletFile := "wallet" + strconv.Itoa(ind) + ".txt"
-		c := client.OpenClient(walletFile, []byte("\x12\x34\x56"))
+		walletFile := "wallet" + strconv.Itoa(ind) + ".dat"
+		c := account.Open(walletFile, []byte(account.DefaultPin))
 		if c == nil {
-			return DnaRpc("do not have wallet file" + walletFile)
+			return DnaRpc("do not have wallet file:" + walletFile)
 		}
 
 		account, _ := c.GetDefaultAccount()
-		pubKey := account.PublicKey
+		pubKey := account.PubKey()
 
 		cert := make([]byte, 100)
 		rand.Read(cert)

--- a/net/httpjsonrpc/interfaces.go
+++ b/net/httpjsonrpc/interfaces.go
@@ -465,6 +465,49 @@ func sendSampleTransaction(params []interface{}) map[string]interface{} {
 			VerifyAndSendTx(regTx)
 		}
 		return DnaRpc(fmt.Sprintf("%d transaction(s) was sent", num))
+	case "bookkeeper":
+		// params:[type, ind, action]
+
+		if len(params) < 3 {
+			return DnaRpcNil
+		}
+		ind := 4
+		switch params[1].(type) {
+		case float64:
+			ind = int(params[1].(float64))
+		}
+		var isAdd bool
+		switch params[2].(type) {
+		case string:
+			action := params[2].(string)
+			if action == "add" {
+				isAdd = true
+			} else if action == "sub" {
+				isAdd = false
+			} else {
+				return DnaRpcInvalidParameter
+			}
+		default:
+			return DnaRpcInvalidParameter
+		}
+
+		walletFile := "wallet" + strconv.Itoa(ind) + ".txt"
+		c := client.OpenClient(walletFile, []byte("\x12\x34\x56"))
+		if c == nil {
+			return DnaRpc("do not have wallet file" + walletFile)
+		}
+
+		account, _ := c.GetDefaultAccount()
+		pubKey := account.PublicKey
+
+		cert := make([]byte, 100)
+		rand.Read(cert)
+
+		bkTx, _ := tx.NewBookKeeperTransaction(pubKey, isAdd, cert)
+		VerifyAndSendTx(bkTx)
+
+		return DnaRpc(fmt.Sprint("bookkeeper transaction was sent, select pubkey file:", walletFile))
+
 	default:
 		return DnaRpc("Invalid transacion type")
 	}


### PR DESCRIPTION
this pull add  support for dynamic bookkeeper list configuration.

1. add a new bookkeeper transaction payload 
2. expose it to httpjsonrpc interface and "nodectl test" sub-command for test purpose
3. change the bookkeeper logic in consensus module
4. add bookkeeper transaction and bookkeeper list logic in ledger store

Usage of "nodectl test" :
remove node 3 from the bookkeeper list:
first copy node3‘s wallet.dat file to the node which nodectl connects to, and rename it to wallet3.dat,
then:
```bash
nodectl test -t bookkeeper -a sub -n 3
```
add node 4 into the bookkeeper list:
first copy node4‘s wallet.dat file to the node which nodectl connects to, and rename it to wallet4.dat,
then:
```bash
nodectl test -t bookkeeper -a add -n 4
```

Signed-off-by: lzc <laizhichao@onchain.com>
