### PR TITLE
fix bug: concurrent access TxPool list

### DIFF
--- a/net/node/infoUpdate.go
+++ b/net/node/infoUpdate.go
@@ -85,12 +85,12 @@ func (node *node) HeartBeatMonitor() {
 	}
 }
 
-func (node node) ReqNeighborList() {
+func (node *node) ReqNeighborList() {
 	buf, _ := NewMsg("getaddr", node.local)
 	go node.Tx(buf)
 }
 
-func (node node) ConnectSeeds() {
+func (node *node) ConnectSeeds() {
 	if node.nbrNodes.GetConnectionCnt() == 0 {
 		seedNodes := config.Parameters.SeedList
 		for _, nodeAddr := range seedNodes {
@@ -102,7 +102,7 @@ func (node node) ConnectSeeds() {
 // FIXME part of node info update function could be a node method itself intead of
 // a node map method
 // Fixme the Nodes should be a parameter
-func (node node) updateNodeInfo() {
+func (node *node) updateNodeInfo() {
 	ticker := time.NewTicker(time.Second * PERIODUPDATETIME)
 	quit := make(chan struct{})
 	for {

--- a/net/node/link.go
+++ b/net/node/link.go
@@ -1,8 +1,8 @@
 package node
 
 import (
-	"DNA/common/log"
 	. "DNA/common/config"
+	"DNA/common/log"
 	. "DNA/net/message"
 	. "DNA/net/protocol"
 	"crypto/tls"
@@ -103,7 +103,7 @@ func printIPAddr() {
 	}
 }
 
-func (link link) CloseConn() {
+func (link *link) CloseConn() {
 	link.conn.Close()
 }
 
@@ -277,7 +277,7 @@ func TLSDial(nodeAddr string) (net.Conn, error) {
 	return conn, nil
 }
 
-func (node node) Tx(buf []byte) {
+func (node *node) Tx(buf []byte) {
 	log.Debug()
 	str := hex.EncodeToString(buf)
 	log.Debug(fmt.Sprintf("TX buf length: %d\n%s", len(buf), str))

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -48,7 +48,7 @@ type node struct {
 	lastContact   time.Time
 }
 
-func (node node) DumpInfo() {
+func (node *node) DumpInfo() {
 	log.Info("Node info:")
 	log.Info("\t state = ", node.state)
 	log.Info(fmt.Sprintf("\t id = 0x%x", node.id))
@@ -123,31 +123,31 @@ func (node *node) backend() {
 	}
 }
 
-func (node node) GetID() uint64 {
+func (node *node) GetID() uint64 {
 	return node.id
 }
 
-func (node node) GetState() uint32 {
+func (node *node) GetState() uint32 {
 	return atomic.LoadUint32(&(node.state))
 }
 
-func (node node) getConn() net.Conn {
+func (node *node) getConn() net.Conn {
 	return node.conn
 }
 
-func (node node) GetPort() uint16 {
+func (node *node) GetPort() uint16 {
 	return node.port
 }
 
-func (node node) GetRelay() bool {
+func (node *node) GetRelay() bool {
 	return node.relay
 }
 
-func (node node) Version() uint32 {
+func (node *node) Version() uint32 {
 	return node.version
 }
 
-func (node node) Services() uint64 {
+func (node *node) Services() uint64 {
 	return node.services
 }
 
@@ -155,11 +155,11 @@ func (node *node) IncRxTxnCnt() {
 	node.rxTxnCnt++
 }
 
-func (node node) GetTxnCnt() uint64 {
+func (node *node) GetTxnCnt() uint64 {
 	return node.txnCnt
 }
 
-func (node node) GetRxTxnCnt() uint64 {
+func (node *node) GetRxTxnCnt() uint64 {
 	return node.rxTxnCnt
 }
 
@@ -171,11 +171,12 @@ func (node *node) CompareAndSetState(old, new uint32) bool {
 	return atomic.CompareAndSwapUint32(&(node.state), old, new)
 }
 
+
 func (node *node) LocalNode() Noder {
 	return node.local
 }
 
-func (node node) GetHeight() uint64 {
+func (node *node) GetHeight() uint64 {
 	return node.height
 }
 
@@ -240,11 +241,11 @@ func (node *node) Xmit(message interface{}) error {
 	return nil
 }
 
-func (node node) GetAddr() string {
+func (node *node) GetAddr() string {
 	return node.addr
 }
 
-func (node node) GetAddr16() ([16]byte, error) {
+func (node *node) GetAddr16() ([16]byte, error) {
 	var result [16]byte
 	ip := net.ParseIP(node.addr).To16()
 	if ip == nil {
@@ -256,16 +257,16 @@ func (node node) GetAddr16() ([16]byte, error) {
 	return result, nil
 }
 
-func (node node) GetTime() int64 {
+func (node *node) GetTime() int64 {
 	t := time.Now()
 	return t.UnixNano()
 }
 
-func (node node) GetBookKeeperAddr() *crypto.PubKey {
+func (node *node) GetBookKeeperAddr() *crypto.PubKey {
 	return node.publicKey
 }
 
-func (node node) GetBookKeepersAddrs() ([]*crypto.PubKey, uint64) {
+func (node *node) GetBookKeepersAddrs() ([]*crypto.PubKey, uint64) {
 	pks := make([]*crypto.PubKey, 1)
 	pks[0] = node.publicKey
 	var i uint64
@@ -285,7 +286,7 @@ func (node *node) SetBookKeeperAddr(pk *crypto.PubKey) {
 	node.publicKey = pk
 }
 
-func (node node) SyncNodeHeight() {
+func (node *node) SyncNodeHeight() {
 	for {
 		heights, _ := node.GetNeighborHeights()
 		if CompareHeight(uint64(ledger.DefaultLedger.Blockchain.BlockHeight), heights) {
@@ -295,7 +296,7 @@ func (node node) SyncNodeHeight() {
 	}
 }
 
-func (node node) WaitForFourPeersStart() {
+func (node *node) WaitForFourPeersStart() {
 	for {
 		log.Debug("WaitForFourPeersStart...")
 		cnt := node.local.GetNbrNodeCnt()
@@ -306,7 +307,7 @@ func (node node) WaitForFourPeersStart() {
 	}
 }
 
-func (node node) IsSyncHeaders() bool {
+func (node *node) IsSyncHeaders() bool {
 	if (node.syncFlag & 0x01) == 0x01 {
 		return true
 	} else {
@@ -322,7 +323,7 @@ func (node *node) SetSyncHeaders(b bool) {
 	}
 }
 
-func (node node) IsSyncFailed() bool {
+func (node *node) IsSyncFailed() bool {
 	if (node.syncFlag & 0x02) == 0x02 {
 		return true
 	} else {
@@ -347,7 +348,7 @@ func (node *node) StartRetryTimer() {
 	}()
 }
 
-func (node node) StopRetryTimer() {
+func (node *node) StopRetryTimer() {
 	node.TxNotifyChan <- 1
 }
 
@@ -355,7 +356,7 @@ func (node *node) StoreFlightHeight(height uint32) {
 	node.flightHeights = append(node.flightHeights, height)
 }
 
-func (node node) GetFlightHeightCnt() int {
+func (node *node) GetFlightHeightCnt() int {
 	return len(node.flightHeights)
 }
 
@@ -386,6 +387,6 @@ func (node *node) RemoveFlightHeight(height uint32) {
 	}
 }
 
-func (node node) GetLastRXTime() time.Time {
+func (node *node) GetLastRXTime() time.Time {
 	return node.time
 }


### PR DESCRIPTION
some method declaration in node struct use object type instead of pointer type.
which lead to several different local node instances and TxPool objects shared the same TxPool list.
cause concurrent access TxPool list and program crash

Signed-off-by: lzc <laizhichao@onchain.com>