### PR TITLE
Fix transaction attribute serialization bug

### DIFF
--- a/core/transaction/transaction.go
+++ b/core/transaction/transaction.go
@@ -263,7 +263,7 @@ func (tx *Transaction) GetProgramHashes() ([]Uint160, error) {
 	}
 	for _, attribute := range tx.Attributes {
 		if attribute.Usage == Script {
-			dataHash, err := Uint160ParseFromBytes(attribute.Date)
+			dataHash, err := Uint160ParseFromBytes(attribute.Data)
 			if err != nil {
 				return nil, NewDetailErr(errors.New("[Transaction], GetProgramHashes err."), ErrNoCode, "")
 			}

--- a/core/transaction/txAttribute.go
+++ b/core/transaction/txAttribute.go
@@ -1,107 +1,69 @@
 package transaction
 
 import (
+	"io"
+
 	"DNA/common/serialization"
 	. "DNA/errors"
-	"io"
 )
 
-//TxAttribute descirbte the specific attributes of transcation
+type TransactionAttributeUsage byte
+
+const (
+	Script         TransactionAttributeUsage = 0x20
+	DescriptionUrl TransactionAttributeUsage = 0x81
+	Description    TransactionAttributeUsage = 0x90
+)
+
 type TxAttribute struct {
 	Usage TransactionAttributeUsage
-	Date  []byte
+	Data  []byte
 	Size  uint32
 }
 
-//to initial a TxAttribute entity with Size calculation and set.
 func NewTxAttribute(u TransactionAttributeUsage, d []byte) TxAttribute {
 	tx := TxAttribute{u, d, 0}
 	tx.Size = tx.GetSize()
 	return tx
 }
 
-//get the TxAttribute entity's size
 func (u *TxAttribute) GetSize() uint32 {
 	if u.Usage == DescriptionUrl {
-		return uint32(len([]byte{(byte(0xff))}) + len([]byte{(byte(0xff))}) + len(u.Date))
+		return uint32(len([]byte{(byte(0xff))}) + len([]byte{(byte(0xff))}) + len(u.Data))
 	}
 	return 0
 }
 
 func (tx *TxAttribute) Serialize(w io.Writer) error {
-	//Usage
-	err := serialization.WriteVarBytes(w, []byte{byte(tx.Usage)})
+	err := serialization.WriteUint8(w, byte(tx.Usage))
 	if err != nil {
-		return NewDetailErr(err, ErrNoCode, "txAttribute serialize Usage error.")
+		return NewDetailErr(err, ErrNoCode, "Transaction attribute Usage serialization error.")
 	}
-	//Date
-	if tx.Usage == DescriptionUrl {
-		err := serialization.WriteVarBytes(w, tx.Date)
+	// TODO other transaction attribute type
+	if tx.Usage == Description || tx.Usage == DescriptionUrl {
+		err := serialization.WriteVarBytes(w, tx.Data)
 		if err != nil {
-			return NewDetailErr(err, ErrNoCode, "txAttribute serialize Date error.")
+			return NewDetailErr(err, ErrNoCode, "Transaction attribute Data serialization error.")
 		}
+	} else {
+		return NewDetailErr(err, ErrNoCode, "Unsupported attribute Description.")
 	}
 	return nil
 }
 
 func (tx *TxAttribute) Deserialize(r io.Reader) error {
-	//Usage
 	val, err := serialization.ReadBytes(r, 1)
 	if err != nil {
-		return NewDetailErr(err, ErrNoCode, "txAttribute Deserialize Usage error.")
+		return NewDetailErr(err, ErrNoCode, "Transaction attribute Usage deserialization error.")
 	}
-	//Date
 	tx.Usage = TransactionAttributeUsage(val[0])
-	if tx.Usage == DescriptionUrl {
-		tx.Date, err = serialization.ReadVarBytes(r)
-		return NewDetailErr(err, ErrNoCode, "txAttribute Deserialize Date error.")
+	if tx.Usage == Description || tx.Usage == DescriptionUrl {
+		tx.Data, err = serialization.ReadVarBytes(r)
+		if err != nil {
+			return NewDetailErr(err, ErrNoCode, "Transaction attribute Data deserialization error.")
+		}
 	} else {
-		return NewDetailErr(err, ErrNoCode, "txAttribute Deserialize format error.")
+		return NewDetailErr(err, ErrNoCode, "Unsupported attribute description.")
 	}
 	return nil
 }
-
-type TransactionAttributeUsage byte
-
-const (
-	ContractHash   TransactionAttributeUsage = 0x00
-	ECDH02         TransactionAttributeUsage = 0x02
-	ECDH03         TransactionAttributeUsage = 0x03
-	Script         TransactionAttributeUsage = 0x20
-	Vote           TransactionAttributeUsage = 0x30
-	DescriptionUrl TransactionAttributeUsage = 0x81
-	Description    TransactionAttributeUsage = 0x90
-
-	Hash1  TransactionAttributeUsage = 0xa1
-	Hash2  TransactionAttributeUsage = 0xa2
-	Hash3  TransactionAttributeUsage = 0xa3
-	Hash4  TransactionAttributeUsage = 0xa4
-	Hash5  TransactionAttributeUsage = 0xa5
-	Hash6  TransactionAttributeUsage = 0xa6
-	Hash7  TransactionAttributeUsage = 0xa7
-	Hash8  TransactionAttributeUsage = 0xa8
-	Hash9  TransactionAttributeUsage = 0xa9
-	Hash10 TransactionAttributeUsage = 0xaa
-	Hash11 TransactionAttributeUsage = 0xab
-	Hash12 TransactionAttributeUsage = 0xac
-	Hash13 TransactionAttributeUsage = 0xad
-	Hash14 TransactionAttributeUsage = 0xae
-	Hash15 TransactionAttributeUsage = 0xaf
-
-	Remark   TransactionAttributeUsage = 0xf0
-	Remark1  TransactionAttributeUsage = 0xf1
-	Remark2  TransactionAttributeUsage = 0xf2
-	Remark3  TransactionAttributeUsage = 0xf3
-	Remark4  TransactionAttributeUsage = 0xf4
-	Remark5  TransactionAttributeUsage = 0xf5
-	Remark6  TransactionAttributeUsage = 0xf6
-	Remark7  TransactionAttributeUsage = 0xf7
-	Remark8  TransactionAttributeUsage = 0xf8
-	Remark9  TransactionAttributeUsage = 0xf9
-	Remark10 TransactionAttributeUsage = 0xfa
-	Remark11 TransactionAttributeUsage = 0xfb
-	Remark12 TransactionAttributeUsage = 0xfc
-	Remark13 TransactionAttributeUsage = 0xfd
-	Remark14 TransactionAttributeUsage = 0xfe
-	Remark15 TransactionAttributeUsage = 0xff
-)

--- a/net/httpjsonrpc/common.go
+++ b/net/httpjsonrpc/common.go
@@ -37,8 +37,7 @@ type ServeMux struct {
 
 type TxAttributeInfo struct {
 	Usage TransactionAttributeUsage
-	Date  string
-	Size  uint32
+	Data  string
 }
 
 type UTXOTxInputInfo struct {

--- a/net/httpjsonrpc/interfaces.go
+++ b/net/httpjsonrpc/interfaces.go
@@ -30,8 +30,7 @@ func TransArryByteToHexString(ptx *tx.Transaction) *Transactions {
 	trans.Attributes = make([]TxAttributeInfo, len(ptx.Attributes))
 	for _, v := range ptx.Attributes {
 		trans.Attributes[n].Usage = v.Usage
-		trans.Attributes[n].Date = ToHexString(v.Date)
-		trans.Attributes[n].Size = v.Size
+		trans.Attributes[n].Data = ToHexString(v.Data)
 		n++
 	}
 


### PR DESCRIPTION
When receive a transaction which has attribute, the transaction can't be
written on chain. The cause is that transaction serialization failed
when do verification. Fix this bug and remove unused transaction
description type.

Signed-off-by: Ziyan Zhou <zhouziyan@hotmail.com>