### PR TITLE
Add privacy payload into DNA

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -11,13 +11,14 @@ import (
 	"DNA/cli/consensus"
 	"DNA/cli/debug"
 	"DNA/cli/info"
+	"DNA/cli/privpayload"
 	"DNA/cli/test"
 	"DNA/cli/wallet"
 	"DNA/common/log"
 	"DNA/crypto"
 
-	"github.com/urfave/cli"
 	"DNA/common/config"
+	"github.com/urfave/cli"
 )
 
 var Version string
@@ -50,6 +51,7 @@ func init() {
 		*test.NewCommand(),
 		*wallet.NewCommand(),
 		*asset.NewCommand(),
+		*privpayload.NewCommand(),
 	}
 	sort.Sort(cli.CommandsByName(app.Commands))
 	sort.Sort(cli.FlagsByName(app.Flags))

--- a/cli/privpayload/privpayload.go
+++ b/cli/privpayload/privpayload.go
@@ -1,0 +1,192 @@
+package privpayload
+
+import (
+	. "DNA/cli/common"
+	"DNA/core/contract"
+	"DNA/core/signature"
+	"DNA/core/transaction"
+	"DNA/core/transaction/payload"
+	"DNA/crypto"
+	"DNA/net/httpjsonrpc"
+	"backup/DNA/client"
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+
+	. "github.com/bitly/go-simplejson"
+	"github.com/urfave/cli"
+)
+
+func makePrivacyTx(admin *client.Account, toPubkeyStr string, pload string) (string, error) {
+	data := []byte(pload)
+	toPk, _ := hex.DecodeString(toPubkeyStr)
+	toPubkey, _ := crypto.DecodePoint(toPk)
+
+	tx, _ := transaction.NewPrivacyPayloadTransaction(admin.PrivateKey, admin.PublicKey, toPubkey, payload.RawPayload, data)
+	tx.Nonce = uint64(rand.Int63())
+	if err := signTransaction(admin, tx); err != nil {
+		fmt.Println("sign regist transaction failed")
+		return "", err
+	}
+
+	var buffer bytes.Buffer
+	if err := tx.Serialize(&buffer); err != nil {
+		fmt.Println("serialize registtransaction failed")
+		return "", err
+	}
+	return hex.EncodeToString(buffer.Bytes()), nil
+}
+
+func signTransaction(signer *client.Account, tx *transaction.Transaction) error {
+	signature, err := signature.SignBySigner(tx, signer)
+	if err != nil {
+		fmt.Println("SignBySigner failed")
+		return err
+	}
+	transactionContract, err := contract.CreateSignatureContract(signer.PubKey())
+	if err != nil {
+		fmt.Println("CreateSignatureContract failed")
+		return err
+	}
+	transactionContractContext := &contract.ContractContext{
+		Data:       tx,
+		Codes:      make([][]byte, 1),
+		Parameters: make([][][]byte, 1),
+	}
+
+	if err := transactionContractContext.AddContract(transactionContract, signer.PubKey(), signature); err != nil {
+		fmt.Println("AddContract failed")
+		return err
+	}
+	tx.SetPrograms(transactionContractContext.GetPrograms())
+	return nil
+}
+
+func privpayloadAction(c *cli.Context) error {
+	if c.NumFlags() == 0 {
+		cli.ShowSubcommandHelp(c)
+		return nil
+	}
+	enc := c.Bool("enc")
+	dec := c.Bool("dec")
+	if !enc && !dec {
+		cli.ShowSubcommandHelp(c)
+		return nil
+	}
+
+	if enc {
+		wallet := client.OpenClient(c.String("name"), []byte(c.String("password")))
+		if wallet == nil {
+			fmt.Println("Failed to open wallet: ", c.String("name"))
+			os.Exit(1)
+		}
+
+		admin, _ := wallet.GetDefaultAccount()
+		data := c.String("data")
+		to := c.String("to")
+
+		txHex, err := makePrivacyTx(admin, to, data)
+		resp, err := httpjsonrpc.Call(Address(), "sendrawtransaction", 0, []interface{}{txHex})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+		FormatOutput(resp)
+	}
+
+	if dec {
+		wallet := client.OpenClient(c.String("name"), []byte(c.String("password")))
+		if wallet == nil {
+			fmt.Println("Failed to open wallet: ", c.String("name"))
+			os.Exit(1)
+		}
+
+		admin, _ := wallet.GetDefaultAccount()
+
+		txhash := c.String("txhash")
+		resp, err := httpjsonrpc.Call(Address(), "getrawtransaction", 0, []interface{}{txhash})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+
+		js, err := NewJson(resp)
+		txType, _ := js.Get("result").Get("TxType").Int()
+		if transaction.TransactionType(txType) != transaction.PrivacyPayload {
+			return errors.New("txType error")
+		}
+
+		plDataStr, _ := js.Get("result").Get("Payload").Get("Payload").String()
+		plData, _ := hex.DecodeString(plDataStr)
+
+		enType, _ := js.Get("result").Get("Payload").Get("EncryptType").Int()
+		switch payload.PayloadEncryptType(enType) {
+		case payload.ECDH_AES256:
+			enAttr, _ := js.Get("result").Get("Payload").Get("EncryptAttr").String()
+			Attr, _ := hex.DecodeString(enAttr)
+			bytesBuffer := bytes.NewBuffer(Attr)
+			encryptAttr := new(payload.EcdhAes256)
+			encryptAttr.Deserialize(bytesBuffer)
+
+			privkey := admin.PrivateKey
+			data, _ := encryptAttr.Decrypt(plData, privkey)
+
+			//		encoding, _ := json.Marshal(map[string]string{"result": hex.EncodeToString(data)})
+			encoding, _ := json.Marshal(map[string]string{"result": string(data)})
+			FormatOutput(encoding)
+
+		default:
+			return errors.New("enType error")
+		}
+	}
+
+	return nil
+}
+
+func NewCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "privpayload",
+		Usage:       "support encryption for payloads",
+		Description: "With nodectl privpayload, you could create privacy payload.",
+		ArgsUsage:   "[args]",
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "enc, e",
+				Usage: "create an privacy  payload",
+			},
+			cli.BoolFlag{
+				Name:  "dec, d",
+				Usage: "decrypt the privacy payload",
+			},
+			cli.StringFlag{
+				Name:  "to",
+				Usage: "payload to whom",
+			},
+			cli.StringFlag{
+				Name:  "data",
+				Usage: "data to be encrypted",
+			},
+			cli.StringFlag{
+				Name:  "name, n",
+				Usage: "wallet name",
+			},
+			cli.StringFlag{
+				Name:  "password, p",
+				Usage: "wallet password",
+			},
+			cli.StringFlag{
+				Name:  "txhash, t",
+				Usage: "hash of a transaction",
+			},
+		},
+		Action: privpayloadAction,
+		OnUsageError: func(c *cli.Context, err error, isSubcommand bool) error {
+			PrintError(c, err, "privacyPayload")
+			return cli.NewExitError("", 1)
+		},
+	}
+}

--- a/core/store/ChainStore/ChainStore.go
+++ b/core/store/ChainStore/ChainStore.go
@@ -634,6 +634,7 @@ func (bd *ChainStore) persist(b *Block) error {
 			b.Transactions[i].TxType == tx.IssueAsset ||
 			b.Transactions[i].TxType == tx.TransferAsset ||
 			b.Transactions[i].TxType == tx.Record ||
+			b.Transactions[i].TxType == tx.PrivacyPayload ||
 			b.Transactions[i].TxType == tx.BookKeeping {
 			err = bd.SaveTransaction(b.Transactions[i], b.Blockdata.Height)
 			if err != nil {

--- a/core/transaction/TransactionBuilder.go
+++ b/core/transaction/TransactionBuilder.go
@@ -81,3 +81,23 @@ func NewRecordTransaction(recordType string, recordData []byte) (*Transaction, e
 	}, nil
 }
 
+func NewPrivacyPayloadTransaction(fromPrivKey []byte, fromPubkey *crypto.PubKey, toPubkey *crypto.PubKey, payloadType payload.EncryptedPayloadType, data []byte) (*Transaction, error) {
+	privacyPayload := &payload.PrivacyPayload{
+		PayloadType: payloadType,
+		EncryptType: payload.ECDH_AES256,
+		EncryptAttr: &payload.EcdhAes256{
+			FromPubkey: fromPubkey,
+			ToPubkey:   toPubkey,
+		},
+	}
+	privacyPayload.Payload, _ = privacyPayload.EncryptAttr.Encrypt(data, fromPrivKey)
+
+	return &Transaction{
+		TxType:        PrivacyPayload,
+		Payload:       privacyPayload,
+		Attributes:    []*TxAttribute{},
+		UTXOInputs:    []*UTXOTxInput{},
+		BalanceInputs: []*BalanceTxInput{},
+		Programs:      []*program.Program{},
+	}, nil
+}

--- a/core/transaction/payload/PrivacyPayload.go
+++ b/core/transaction/payload/PrivacyPayload.go
@@ -1,0 +1,184 @@
+package payload
+
+import (
+	"DNA/common/serialization"
+	"DNA/crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"io"
+	mrand "math/rand"
+	"time"
+)
+
+type EncryptedPayloadType byte
+
+type EncryptedPayload []byte
+
+type PayloadEncryptType byte
+
+type PayloadEncryptAttr interface {
+	Serialize(w io.Writer) error
+	Deserialize(r io.Reader) error
+	Encrypt(msg []byte, keys interface{}) ([]byte, error)
+	Decrypt(msg []byte, keys interface{}) ([]byte, error)
+}
+
+const (
+	ECDH_AES256 PayloadEncryptType = 0x01
+)
+const (
+	RawPayload EncryptedPayloadType = 0x01
+)
+
+type PrivacyPayload struct {
+	PayloadType EncryptedPayloadType
+	Payload     EncryptedPayload
+	EncryptType PayloadEncryptType
+	EncryptAttr PayloadEncryptAttr
+}
+
+func (pp *PrivacyPayload) Data() []byte {
+	//TODO: implement PrivacyPayload.Data()
+	return []byte{0}
+}
+
+func (pp *PrivacyPayload) Serialize(w io.Writer) error {
+	w.Write([]byte{byte(pp.PayloadType)})
+	err := serialization.WriteVarBytes(w, pp.Payload)
+	if err != nil {
+		return err
+	}
+	w.Write([]byte{byte(pp.EncryptType)})
+	err = pp.EncryptAttr.Serialize(w)
+
+	return err
+}
+
+func (pp *PrivacyPayload) Deserialize(r io.Reader) error {
+	var PayloadType [1]byte
+	_, err := io.ReadFull(r, PayloadType[:])
+	if err != nil {
+		return err
+	}
+	pp.PayloadType = EncryptedPayloadType(PayloadType[0])
+
+	Payload, err := serialization.ReadVarBytes(r)
+	if err != nil {
+		return err
+	}
+	pp.Payload = Payload
+
+	var encryptType [1]byte
+	_, err = io.ReadFull(r, encryptType[:])
+	if err != nil {
+		return err
+	}
+	pp.EncryptType = PayloadEncryptType(encryptType[0])
+
+	switch pp.EncryptType {
+	case ECDH_AES256:
+		pp.EncryptAttr = new(EcdhAes256)
+	default:
+		return errors.New("unknown EncryptType")
+	}
+	err = pp.EncryptAttr.Deserialize(r)
+
+	return err
+}
+
+type EcdhAes256 struct {
+	FromPubkey *crypto.PubKey
+	ToPubkey   *crypto.PubKey
+	Nonce      []byte
+}
+
+func (ea *EcdhAes256) Serialize(w io.Writer) error {
+	err := ea.FromPubkey.Serialize(w)
+	if err != nil {
+		return err
+	}
+	err = ea.ToPubkey.Serialize(w)
+	if err != nil {
+		return err
+	}
+	err = serialization.WriteVarBytes(w, ea.Nonce)
+	return err
+}
+func (ea *EcdhAes256) Deserialize(r io.Reader) error {
+	ea.FromPubkey = new(crypto.PubKey)
+	err := ea.FromPubkey.DeSerialize(r)
+	if err != nil {
+		return err
+	}
+
+	ea.ToPubkey = new(crypto.PubKey)
+	err = ea.ToPubkey.DeSerialize(r)
+	if err != nil {
+		return err
+	}
+
+	nonce, err := serialization.ReadVarBytes(r)
+	if err != nil {
+		return err
+	}
+	ea.Nonce = nonce
+	return nil
+}
+
+func (ea *EcdhAes256) Encrypt(msg []byte, keys interface{}) ([]byte, error) {
+	var key []byte
+	switch keys.(type) {
+	case []byte:
+		key = keys.([]byte)
+	default:
+		return []byte{}, errors.New("The keys error")
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return []byte{}, err
+	}
+	x, _ := priv.Curve.ScalarMult(ea.ToPubkey.X, ea.ToPubkey.Y, key)
+	aesKey := make([]byte, 32)
+	copy(aesKey[32-len(x.Bytes()):], x.Bytes())
+
+	iv := make([]byte, 16)
+	r := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 16; i++ {
+		iv[i] = byte(r.Intn(256))
+	}
+
+	paddingData := crypto.PKCS5Padding(msg, 16)
+	encryption, err := crypto.AesEncrypt(paddingData, aesKey, iv)
+	if err != nil {
+		return []byte{}, err
+	}
+	ea.Nonce = iv
+
+	return encryption, nil
+}
+
+func (ea *EcdhAes256) Decrypt(msg []byte, keys interface{}) ([]byte, error) {
+	var key []byte
+	switch keys.(type) {
+	case []byte:
+		key = keys.([]byte)
+	default:
+		return []byte{}, errors.New("The keys error")
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return []byte{}, err
+	}
+	x, _ := priv.Curve.ScalarMult(ea.FromPubkey.X, ea.FromPubkey.Y, key)
+	aesKey := make([]byte, 32)
+	copy(aesKey[32-len(x.Bytes()):], x.Bytes())
+
+	decryption, _ := crypto.AesDecrypt(msg, aesKey, ea.Nonce)
+	result := crypto.PKCS5UnPadding(decryption)
+
+	return result, nil
+}

--- a/glide.lock
+++ b/glide.lock
@@ -26,4 +26,6 @@ imports:
   version: b6649477bfe6276322b4eeaae8f5e947b49cec92
 - name: github.com/urfave/cli
   version: f6e8084112db1c3aa9c1e4144f024ab549ea08c1
+- name: github.com/bitly/go-simplejson
+  version: da1a8928f709389522c8023062a3739f3b4af419
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,3 +11,4 @@ import:
   - leveldb/opt
 - package: github.com/tv42/base58
 - package: github.com/urfave/cli
+- package: github.com/bitly/go-simplejson

--- a/net/httpjsonrpc/TransPayloadToHex.go
+++ b/net/httpjsonrpc/TransPayloadToHex.go
@@ -6,6 +6,7 @@ import (
 	. "DNA/core/contract"
 	. "DNA/core/transaction"
 	"DNA/core/transaction/payload"
+	"bytes"
 )
 
 type PayloadInfo interface {
@@ -81,6 +82,17 @@ func (a *RecordInfo) Data() []byte {
 	return []byte{0}
 }
 
+type PrivacyPayloadInfo struct {
+	PayloadType uint8
+	Payload     string
+	EncryptType uint8
+	EncryptAttr string
+}
+
+func (a *PrivacyPayloadInfo) Data() []byte {
+	return []byte{0}
+}
+
 func TransPayloadToHex(p Payload) PayloadInfo {
 	switch object := p.(type) {
 	case *payload.BookKeeping:
@@ -110,6 +122,16 @@ func TransPayloadToHex(p Payload) PayloadInfo {
 		obj.RecordType = object.RecordType
 		obj.RecordData = ToHexString(object.RecordData)
 		return obj
+	case *payload.PrivacyPayload:
+		obj := new(PrivacyPayloadInfo)
+		obj.PayloadType = uint8(object.PayloadType)
+		obj.Payload = ToHexString(object.Payload)
+		obj.EncryptType = uint8(object.EncryptType)
+		bytesBuffer := bytes.NewBuffer([]byte{})
+		object.EncryptAttr.Serialize(bytesBuffer)
+		obj.EncryptAttr = ToHexString(bytesBuffer.Bytes())
+		return obj
+
 	}
 	return nil
 }


### PR DESCRIPTION
Add an New type payload into DNA. This payload can contain raw data or
the payload of other type. User can use a nodectl's command "ppayload"
to get a privacy payload.

Signed-off-by: d5c5ceb0 <d5c5ceb0@gmail.com>