### PR TITLE
transaction balance serialization

### DIFF
--- a/cli/asset/asset.go
+++ b/cli/asset/asset.go
@@ -1,6 +1,14 @@
 package asset
 
 import (
+	"DNA/account"
+	. "DNA/cli/common"
+	. "DNA/common"
+	. "DNA/core/asset"
+	"DNA/core/contract"
+	"DNA/core/signature"
+	"DNA/core/transaction"
+	"DNA/net/httpjsonrpc"
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
@@ -9,14 +17,6 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
-	. "DNA/cli/common"
-	"DNA/account"
-	. "DNA/common"
-	. "DNA/core/asset"
-	"DNA/core/contract"
-	"DNA/core/signature"
-	"DNA/core/transaction"
-	"DNA/net/httpjsonrpc"
 
 	"github.com/urfave/cli"
 )
@@ -98,7 +98,9 @@ func makeRegTransaction(admin, issuer *account.Account, name string, value Fixed
 		return "", err
 	}
 	tx, _ := transaction.NewRegisterAssetTransaction(asset, value, issuer.PubKey(), transactionContract.ProgramHash)
-	tx.Nonce = uint64(rand.Int63())
+	txAttr := transaction.NewTxAttribute(transaction.Nonce, []byte(strconv.FormatInt(rand.Int63(), 10)))
+	tx.Attributes = make([]*transaction.TxAttribute, 0)
+	tx.Attributes = append(tx.Attributes, &txAttr)
 	if err := signTransaction(issuer, tx); err != nil {
 		fmt.Println("sign regist transaction failed")
 		return "", err
@@ -123,7 +125,9 @@ func makeIssueTransaction(issuer *account.Account, programHashStr, assetHashStr 
 	}
 	outputs := []*transaction.TxOutput{issueTxOutput}
 	tx, _ := transaction.NewIssueAssetTransaction(outputs)
-	tx.Nonce = uint64(rand.Int63())
+	txAttr := transaction.NewTxAttribute(transaction.Nonce, []byte(strconv.FormatInt(rand.Int63(), 10)))
+	tx.Attributes = make([]*transaction.TxAttribute, 0)
+	tx.Attributes = append(tx.Attributes, &txAttr)
 	if err := signTransaction(issuer, tx); err != nil {
 		fmt.Println("sign issue transaction failed")
 		return "", err
@@ -214,7 +218,9 @@ func makeTransferTransaction(signer *account.Account, programHashStr, assetHashS
 		return "", errors.New("transfer failed, ammount is not enough")
 	}
 	tx, _ := transaction.NewTransferAssetTransaction(inputs, outputs)
-	tx.Nonce = uint64(rand.Int63())
+	txAttr := transaction.NewTxAttribute(transaction.Nonce, []byte(strconv.FormatInt(rand.Int63(), 10)))
+	tx.Attributes = make([]*transaction.TxAttribute, 0)
+	tx.Attributes = append(tx.Attributes, &txAttr)
 	if err := signTransaction(signer, tx); err != nil {
 		fmt.Println("sign transfer transaction failed")
 		return "", err

--- a/cli/privpayload/privpayload.go
+++ b/cli/privpayload/privpayload.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/bitly/go-simplejson"
 	"github.com/urfave/cli"
+	"strconv"
 )
 
 func makePrivacyTx(admin *account.Account, toPubkeyStr string, pload string) (string, error) {
@@ -27,7 +28,9 @@ func makePrivacyTx(admin *account.Account, toPubkeyStr string, pload string) (st
 	toPubkey, _ := crypto.DecodePoint(toPk)
 
 	tx, _ := transaction.NewPrivacyPayloadTransaction(admin.PrivateKey, admin.PublicKey, toPubkey, payload.RawPayload, data)
-	tx.Nonce = uint64(rand.Int63())
+	txAttr := transaction.NewTxAttribute(transaction.Nonce, []byte(strconv.FormatInt(rand.Int63(), 10)))
+	tx.Attributes = make([]*transaction.TxAttribute, 0)
+	tx.Attributes = append(tx.Attributes, &txAttr)
 	if err := signTransaction(admin, tx); err != nil {
 		fmt.Println("sign regist transaction failed")
 		return "", err

--- a/consensus/dbft/dbftService.go
+++ b/consensus/dbft/dbftService.go
@@ -186,7 +186,6 @@ func (ds *DbftService) CreateBookkeepingTransaction(nonce uint64) *tx.Transactio
 		TxType:         tx.BookKeeping,
 		PayloadVersion: 0x2,
 		Payload:        &payload.BookKeeping{},
-		Nonce:          nonce, //TODO: update the nonce
 		Attributes:     []*tx.TxAttribute{},
 		UTXOInputs:     []*tx.UTXOTxInput{},
 		BalanceInputs:  []*tx.BalanceTxInput{},

--- a/core/ledger/block.go
+++ b/core/ledger/block.go
@@ -171,7 +171,6 @@ func GenesisBlockInit() (*Block, error) {
 		trans.TxType = tx.BookKeeping
 		trans.PayloadVersion = byte(0)
 		trans.Payload = nil
-		trans.Nonce = uint64(0)
 		trans.Attributes = nil
 		trans.UTXOInputs = nil
 		trans.BalanceInputs = nil

--- a/core/transaction/transaction.go
+++ b/core/transaction/transaction.go
@@ -52,7 +52,6 @@ type Transaction struct {
 	TxType         TransactionType
 	PayloadVersion byte
 	Payload        Payload
-	Nonce          uint64
 	Attributes     []*TxAttribute
 	UTXOInputs     []*UTXOTxInput
 	BalanceInputs  []*BalanceTxInput
@@ -102,8 +101,6 @@ func (tx *Transaction) SerializeUnsigned(w io.Writer) error {
 		return errors.New("Transaction Payload is nil.")
 	}
 	tx.Payload.Serialize(w)
-	//nonce
-	serialization.WriteVarUint(w, tx.Nonce)
 	//[]*txAttribute
 	err := serialization.WriteVarUint(w, uint64(len(tx.Attributes)))
 	if err != nil {
@@ -199,14 +196,8 @@ func (tx *Transaction) DeserializeUnsignedWithoutType(r io.Reader) error {
 	}
 
 	tx.Payload.Deserialize(r)
+
 	//attributes
-
-	nonce, err := serialization.ReadVarUint(r, 0)
-	if err != nil {
-		return errors.New("Parse nonce error")
-	}
-	tx.Nonce = nonce
-
 	Len, err := serialization.ReadVarUint(r, 0)
 	if err != nil {
 		return err

--- a/core/transaction/txAttribute.go
+++ b/core/transaction/txAttribute.go
@@ -10,6 +10,7 @@ import (
 type TransactionAttributeUsage byte
 
 const (
+	Nonce          TransactionAttributeUsage = 0x00
 	Script         TransactionAttributeUsage = 0x20
 	DescriptionUrl TransactionAttributeUsage = 0x81
 	Description    TransactionAttributeUsage = 0x90

--- a/net/httpjsonrpc/common.go
+++ b/net/httpjsonrpc/common.go
@@ -74,7 +74,6 @@ type Transactions struct {
 	TxType         TransactionType
 	PayloadVersion byte
 	Payload        PayloadInfo
-	Nonce          uint64
 	Attributes     []TxAttributeInfo
 	UTXOInputs     []UTXOTxInputInfo
 	BalanceInputs  []BalanceTxInputInfo

--- a/net/httpjsonrpc/interfaces.go
+++ b/net/httpjsonrpc/interfaces.go
@@ -24,7 +24,6 @@ func TransArryByteToHexString(ptx *tx.Transaction) *Transactions {
 	trans.TxType = ptx.TxType
 	trans.PayloadVersion = ptx.PayloadVersion
 	trans.Payload = TransPayloadToHex(ptx.Payload)
-	trans.Nonce = ptx.Nonce
 
 	n := 0
 	trans.Attributes = make([]TxAttributeInfo, len(ptx.Attributes))


### PR DESCRIPTION
In order to be consistent with antshare's transaction serialization.
when with no balance, there is need to serialize nonce. just skip it
when serialization

Signed-off-by: luodanwg <luodan.wg@gmail.com>