### PR TITLE
 fix the  misuse of NewDetailErr function

### DIFF
--- a/core/transaction/transaction.go
+++ b/core/transaction/transaction.go
@@ -292,14 +292,14 @@ func (tx *Transaction) GetProgramHashes() ([]Uint160, error) {
 				return nil, NewDetailErr(err, ErrNoCode, fmt.Sprintf("[Transaction], GetTransaction failed With AssetID:=%x", k))
 			}
 			if tx.TxType != RegisterAsset {
-				return nil, NewDetailErr(err, ErrNoCode, fmt.Sprintf("[Transaction], Transaction Type ileage With AssetID:=%x", k))
+				return nil, NewDetailErr(errors.New("[Transaction] error"), ErrNoCode, fmt.Sprintf("[Transaction], Transaction Type ileage With AssetID:=%x", k))
 			}
 
 			switch v1 := tx.Payload.(type) {
 			case *payload.RegisterAsset:
 				hashs = append(hashs, v1.Controller)
 			default:
-				return nil, NewDetailErr(err, ErrNoCode, fmt.Sprintf("[Transaction], payload is illegal", k))
+				return nil, NewDetailErr(errors.New("[Transaction] error"), ErrNoCode, fmt.Sprintf("[Transaction], payload is illegal", k))
 			}
 		}
 	case TransferAsset:

--- a/core/transaction/txAttribute.go
+++ b/core/transaction/txAttribute.go
@@ -1,10 +1,10 @@
 package transaction
 
 import (
-	"io"
-
 	"DNA/common/serialization"
 	. "DNA/errors"
+	"errors"
+	"io"
 )
 
 type TransactionAttributeUsage byte
@@ -47,7 +47,7 @@ func (tx *TxAttribute) Serialize(w io.Writer) error {
 			return NewDetailErr(err, ErrNoCode, "Transaction attribute Data serialization error.")
 		}
 	} else {
-		return NewDetailErr(err, ErrNoCode, "Unsupported attribute Description.")
+		return NewDetailErr(errors.New("[TxAttribute] error"), ErrNoCode, "Unsupported attribute Description.")
 	}
 	return nil
 }
@@ -64,7 +64,7 @@ func (tx *TxAttribute) Deserialize(r io.Reader) error {
 			return NewDetailErr(err, ErrNoCode, "Transaction attribute Data deserialization error.")
 		}
 	} else {
-		return NewDetailErr(err, ErrNoCode, "Unsupported attribute description.")
+		return NewDetailErr(errors.New("[TxAttribute] error"), ErrNoCode, "Unsupported attribute description.")
 	}
 	return nil
 }

--- a/core/validation/blockValidator.go
+++ b/core/validation/blockValidator.go
@@ -76,15 +76,15 @@ func VerifyBlockData(bd *ledger.Blockdata, ledger *ledger.Ledger) error {
 		return NewDetailErr(err, ErrNoCode, "[BlockValidator], Cannnot find prevHeader..")
 	}
 	if prevHeader == nil {
-		return NewDetailErr(err, ErrNoCode, "[BlockValidator], Cannnot find previous block.")
+		return NewDetailErr(errors.New("[BlockValidator] error"), ErrNoCode, "[BlockValidator], Cannnot find previous block.")
 	}
 
 	if prevHeader.Blockdata.Height+1 != bd.Height {
-		return NewDetailErr(err, ErrNoCode, "[BlockValidator], block height is incorrect.")
+		return NewDetailErr(errors.New("[BlockValidator] error"), ErrNoCode, "[BlockValidator], block height is incorrect.")
 	}
 
 	if prevHeader.Blockdata.Timestamp >= bd.Timestamp {
-		return NewDetailErr(err, ErrNoCode, "[BlockValidator], block timestamp is incorrect.")
+		return NewDetailErr(errors.New("[BlockValidator] error"), ErrNoCode, "[BlockValidator], block timestamp is incorrect.")
 	}
 
 	return nil


### PR DESCRIPTION
when err is nil, function NewDetailErr returns nil.
so when called in the case the function will eat the error.
cause confusing result and misleading execution flow.

Signed-off-by: lzc <laizhichao@onchain.com>