### PR TITLE
use dot instead of colon naming the log

### DIFF
--- a/common/log/log.go
+++ b/common/log/log.go
@@ -217,7 +217,7 @@ func FileOpen(path string) (*os.File, error) {
 		return nil, err
 	}
 
-	var currenttime string = time.Now().Format("2006-01-02_15:04:05")
+	var currenttime string = time.Now().Format("2006-01-02_15.04.05")
 
 	logfile, err := os.OpenFile(path+currenttime+"_LOG.log", os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {


### PR DESCRIPTION
Windows system cann't use colon naming files or folders,
so use dot instead of colon naming the log.

Signed-off-by: Jin Qing <1091147665@qq.com>