### PR TITLE
fix logic error in GetHeadersFromHash function

### DIFF
--- a/net/message/blockHdr.go
+++ b/net/message/blockHdr.go
@@ -196,7 +196,7 @@ func GetHeadersFromHash(startHash common.Uint256, stopHash common.Uint256) ([]le
 			}
 			stopHeight = bkstop.Blockdata.Height
 			count = curHeight - stopHeight
-			if curHeight > MAXBLKHDRCNT {
+			if count > MAXBLKHDRCNT {
 				count = MAXBLKHDRCNT
 			}
 		}
@@ -215,7 +215,7 @@ func GetHeadersFromHash(startHash common.Uint256, stopHash common.Uint256) ([]le
 			count = startHeight - stopHeight
 			if count >= MAXBLKHDRCNT {
 				count = MAXBLKHDRCNT
-				stopHeight = startHeight + MAXBLKHDRCNT
+				stopHeight = startHeight - MAXBLKHDRCNT
 			}
 		} else {
 


### PR DESCRIPTION
currently this function's intention is :
1) startHash == empty, stopHash == empty: return headers in range [1, min(2000, curHeight)];
2) startHash == empty, stopHash != empty: return headers in range [hstop, hstop + min(2000, curHeight)]
3) startHash != empty, stopHash == empty: return headers in range [0, min(2000, hstart)]
4) startHash != empty, stopHash != empty: return headers in range [max(hstop, hstart - 2000), hstart]

the implementation code have two issues:
in condition 2 : when curHeight > 2000, return headers in range [hstop, hstop + 2000],
                  which may cause error in the following for loop if curHeight < hstop + 2000
in condition 4: if hstart - hstop > 2000, return headers in range [hstart+ 2000, hstart + 4000],
                 also will cause error.

Signed-off-by: lzc <laizhichao@onchain.com>