### PR TITLE
Remove default wallet password

### DIFF
--- a/account/client.go
+++ b/account/client.go
@@ -16,6 +16,7 @@ import (
 	. "DNA/common"
 	"DNA/common/config"
 	"DNA/common/log"
+	"DNA/common/password"
 	"DNA/core/contract"
 	ct "DNA/core/contract"
 	"DNA/core/ledger"
@@ -23,16 +24,12 @@ import (
 	"DNA/crypto"
 	. "DNA/errors"
 	"DNA/net/protocol"
-
-	"github.com/dnaproject/gopass"
 )
 
 const (
 	DefaultBookKeeperCount = 4
 	WalletFileName         = "wallet.dat"
 )
-
-var DefaultPin = "passwordtest"
 
 type Client interface {
 	Sign(context *ct.ContractContext) bool
@@ -508,8 +505,7 @@ func GetClient() Client {
 		log.Error(fmt.Sprintf("No %s detected, please create a wallet by using command line.", WalletFileName))
 		os.Exit(1)
 	}
-	fmt.Println("Password:")
-	passwd, err := gopass.GetPasswd()
+	passwd, err := password.GetAccountPassword()
 	if err != nil {
 		log.Error("Get password error.")
 		os.Exit(1)

--- a/cli/asset/asset.go
+++ b/cli/asset/asset.go
@@ -246,7 +246,7 @@ func assetAction(c *cli.Context) error {
 		return nil
 	}
 
-	wallet := openWallet(c.String("wallet"), []byte(c.String("password")))
+	wallet := openWallet(c.String("wallet"), WalletPassword(c.String("password")))
 	admin, _ := wallet.GetDefaultAccount()
 	value := c.Int64("value")
 	if value == 0 {
@@ -319,7 +319,6 @@ func NewCommand() *cli.Command {
 			cli.StringFlag{
 				Name:  "password, p",
 				Usage: "wallet password",
-				Value: account.DefaultPin,
 			},
 			cli.StringFlag{
 				Name:  "asset, a",

--- a/cli/common/common.go
+++ b/cli/common/common.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"DNA/common/config"
+	"DNA/common/password"
 
 	"github.com/urfave/cli"
 )
@@ -56,4 +57,15 @@ func FormatOutput(o []byte) error {
 	_, err = out.WriteTo(os.Stdout)
 
 	return err
+}
+
+// WalletPassword prompts user to input wallet password when password is not
+// specified from command line
+func WalletPassword(passwd string) []byte {
+	if passwd == "" {
+		tmppasswd, _ := password.GetPassword()
+		return tmppasswd
+	} else {
+		return []byte(passwd)
+	}
 }

--- a/cli/data/data.go
+++ b/cli/data/data.go
@@ -146,7 +146,7 @@ func dataAction(c *cli.Context) error {
 		//create transaction
 		var tx *transaction.Transaction
 
-		wallet := openWallet(c.String("wallet"), []byte(c.String("password")))
+		wallet := openWallet(c.String("wallet"), WalletPassword(c.String("password")))
 		admin, _ := wallet.GetDefaultAccount()
 
 		tx, _ = transaction.NewDataFileTransaction(address, name, "", admin.PubKey())
@@ -252,7 +252,6 @@ This command can be used to manage data on chain.
 			},
 			cli.StringFlag{
 				Name:  "password, p",
-				Value: account.DefaultPin,
 				Usage: "password",
 			},
 			cli.StringFlag{

--- a/cli/privpayload/privpayload.go
+++ b/cli/privpayload/privpayload.go
@@ -80,15 +80,13 @@ func privpayloadAction(c *cli.Context) error {
 		cli.ShowSubcommandHelp(c)
 		return nil
 	}
-
+	wallet := account.Open(c.String("wallet"), WalletPassword(c.String("password")))
+	if wallet == nil {
+		fmt.Println("Failed to open wallet: ", c.String("wallet"))
+		os.Exit(1)
+	}
+	admin, _ := wallet.GetDefaultAccount()
 	if enc {
-		wallet := account.Open(c.String("wallet"), []byte(c.String("password")))
-		if wallet == nil {
-			fmt.Println("Failed to open wallet: ", c.String("wallet"))
-			os.Exit(1)
-		}
-
-		admin, _ := wallet.GetDefaultAccount()
 		data := c.String("data")
 		to := c.String("to")
 
@@ -102,14 +100,6 @@ func privpayloadAction(c *cli.Context) error {
 	}
 
 	if dec {
-		wallet := account.Open(c.String("wallet"), []byte(c.String("password")))
-		if wallet == nil {
-			fmt.Println("Failed to open wallet: ", c.String("wallet"))
-			os.Exit(1)
-		}
-
-		admin, _ := wallet.GetDefaultAccount()
-
 		txhash := c.String("txhash")
 		resp, err := httpjsonrpc.Call(Address(), "getrawtransaction", 0, []interface{}{txhash})
 		if err != nil {
@@ -180,6 +170,7 @@ func NewCommand() *cli.Command {
 			cli.StringFlag{
 				Name:  "wallet, w",
 				Usage: "wallet name",
+				Value: account.WalletFileName,
 			},
 			cli.StringFlag{
 				Name:  "password, p",

--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -10,74 +10,98 @@ import (
 	"DNA/account"
 	. "DNA/cli/common"
 	. "DNA/common"
+	"DNA/common/password"
 	"DNA/core/contract"
 	"DNA/net/httpjsonrpc"
 
 	"github.com/urfave/cli"
 )
 
-func walletAction(c *cli.Context) (err error) {
+func walletAction(c *cli.Context) error {
 	if c.NumFlags() == 0 {
 		cli.ShowSubcommandHelp(c)
 		return nil
 	}
-	createWallet := c.Bool("create")
-	list := c.Bool("list")
+	// wallet name is wallet.dat by default
 	name := c.String("name")
+	create := c.Bool("create")
+	list := c.Bool("list")
 	passwd := c.String("password")
-	if name != "" && passwd != "" {
-		var wallet *account.ClientImpl
-		if createWallet {
-			wallet = account.Create(name, []byte(passwd))
-		} else if list {
-			wallet = account.Open(name, []byte(passwd))
+	if name == "" {
+		fmt.Println("Invalid wallet name.")
+		os.Exit(1)
+	}
+	if FileExisted(name) && create {
+		fmt.Printf("CAUTION: '%s' already exists!\n", name)
+		os.Exit(1)
+	}
+	// need to input password when password is not specified from command line
+	if passwd == "" {
+		var err error
+		var tmppasswd []byte
+		if create {
+			tmppasswd, err = password.GetConfirmedPassword()
+		} else {
+			tmppasswd, err = password.GetPassword()
 		}
-		if wallet == nil {
-			fmt.Println("Failed to open wallet: ", name)
+		if err != nil {
+			fmt.Println(err)
 			os.Exit(1)
 		}
-		account, _ := wallet.GetDefaultAccount()
-		pubKey := account.PubKey()
-		signatureRedeemScript, _ := contract.CreateSignatureRedeemScript(pubKey)
-		programHash, _ := ToCodeHash(signatureRedeemScript)
-		encodedPubKey, _ := pubKey.EncodePoint(true)
-		asset := c.String("asset")
-		if asset == "" {
-			fmt.Println("public key:   ", ToHexString(encodedPubKey))
-			fmt.Println("program hash: ", ToHexString(programHash.ToArray()))
-			fmt.Println("address:      ", programHash.ToAddress())
+		passwd = string(tmppasswd)
+	}
+	var wallet *account.ClientImpl
+	if create {
+		wallet = account.Create(name, []byte(passwd))
+	} else if list {
+		wallet = account.Open(name, []byte(passwd))
+	}
+	if wallet == nil {
+		fmt.Println("Failed to open wallet: ", name)
+		os.Exit(1)
+	}
+	fmt.Printf("Wallet File: '%s'\n", name)
+	account, _ := wallet.GetDefaultAccount()
+	pubKey := account.PubKey()
+	signatureRedeemScript, _ := contract.CreateSignatureRedeemScript(pubKey)
+	programHash, _ := ToCodeHash(signatureRedeemScript)
+	encodedPubKey, _ := pubKey.EncodePoint(true)
+	asset := c.String("asset")
+	if asset == "" {
+		fmt.Println("public key:   ", ToHexString(encodedPubKey))
+		fmt.Println("program hash: ", ToHexString(programHash.ToArray()))
+		fmt.Println("address:      ", programHash.ToAddress())
+	}
+	if list && asset != "" {
+		var buffer bytes.Buffer
+		_, err := programHash.Serialize(&buffer)
+		if err != nil {
+			return err
 		}
-		if list && asset != "" {
-			var buffer bytes.Buffer
-			_, err := programHash.Serialize(&buffer)
-			if err != nil {
-				return err
+		resp, err := httpjsonrpc.Call(Address(), "getunspendoutput", 0,
+			[]interface{}{hex.EncodeToString(buffer.Bytes()), asset})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+		r := make(map[string]interface{})
+		err = json.Unmarshal(resp, &r)
+		if err != nil {
+			fmt.Println("Unmarshal JSON failed")
+			return err
+		}
+		switch r["result"].(type) {
+		case map[string]interface{}:
+			ammount := 0
+			unspend := r["result"].(map[string]interface{})
+			for _, v := range unspend {
+				out := v.(map[string]interface{})
+				ammount += int(out["Value"].(float64))
 			}
-			resp, err := httpjsonrpc.Call(Address(), "getunspendoutput", 0,
-				[]interface{}{hex.EncodeToString(buffer.Bytes()), asset})
-			if err != nil {
-				fmt.Fprintln(os.Stderr, err)
-				return err
-			}
-			r := make(map[string]interface{})
-			err = json.Unmarshal(resp, &r)
-			if err != nil {
-				fmt.Println("Unmarshal JSON failed")
-				return err
-			}
-			switch r["result"].(type) {
-			case map[string]interface{}:
-				ammount := 0
-				unspend := r["result"].(map[string]interface{})
-				for _, v := range unspend {
-					out := v.(map[string]interface{})
-					ammount += int(out["Value"].(float64))
-				}
-				fmt.Println("Ammount: ", ammount)
-			case string:
-				fmt.Println(r["result"].(string))
-				return nil
-			}
+			fmt.Println("Ammount: ", ammount)
+		case string:
+			fmt.Println(r["result"].(string))
+			return nil
 		}
 	}
 	return nil
@@ -110,7 +134,6 @@ func NewCommand() *cli.Command {
 			cli.StringFlag{
 				Name:  "password, p",
 				Usage: "wallet password",
-				Value: account.DefaultPin,
 			},
 		},
 		Action: walletAction,

--- a/common/password/password.go
+++ b/common/password/password.go
@@ -1,0 +1,67 @@
+package password
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/dnaproject/gopass"
+)
+
+// GetPassword gets password from user input
+func GetPassword() ([]byte, error) {
+	fmt.Printf("Password:")
+	passwd, err := gopass.GetPasswd()
+	if err != nil {
+		return nil, err
+	}
+	return passwd, nil
+}
+
+// GetConfirmedPassword gets double confirmed password from user input
+func GetConfirmedPassword() ([]byte, error) {
+	fmt.Printf("Password:")
+	first, err := gopass.GetPasswd()
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("Re-enter Password:")
+	second, err := gopass.GetPasswd()
+	if err != nil {
+		return nil, err
+	}
+	if len(first) != len(second) {
+		fmt.Println("Unmatched Password")
+		os.Exit(1)
+	}
+	for i, v := range first {
+		if v != second[i] {
+			fmt.Println("Unmatched Password")
+			os.Exit(1)
+		}
+	}
+	return first, nil
+}
+
+// GetPassword gets node's wallet password from command line or user input
+func GetAccountPassword() ([]byte, error) {
+	var passwd []byte
+	var err error
+	if len(os.Args) == 1 {
+		passwd, err = GetPassword()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var pstr string
+		flag.StringVar(&pstr, "p", "", "wallet password")
+		flag.Parse()
+		if pstr == "" {
+			fmt.Println("Invaild parameter, use '-p <password>' to specify a not nil wallet password.")
+			os.Exit(1)
+		}
+		passwd = []byte(pstr)
+	}
+
+	return passwd, nil
+}

--- a/net/httpjsonrpc/interfaces.go
+++ b/net/httpjsonrpc/interfaces.go
@@ -474,8 +474,13 @@ func sendSampleTransaction(params []interface{}) map[string]interface{} {
 		}
 		return DnaRpc(fmt.Sprintf("%d transaction(s) was sent", num))
 	case "bookkeeper":
-		// params:[type, ind, action]
+		//TODO Since each node only keep a wallet.dat for itself, the necessary public key
+		// and certification should be re-constructed. This bookkeeper test is invalid now
+		// and will be moved to nodectl as a subcommand then user could pass applicable
+		// public key and cert.
+		return DnaRpcUnsupported
 
+		// params:[type, ind, action]
 		if len(params) < 3 {
 			return DnaRpcNil
 		}
@@ -500,7 +505,7 @@ func sendSampleTransaction(params []interface{}) map[string]interface{} {
 		}
 
 		walletFile := "wallet" + strconv.Itoa(ind) + ".dat"
-		c := account.Open(walletFile, []byte(account.DefaultPin))
+		c := account.Open(walletFile, []byte("no default password"))
 		if c == nil {
 			return DnaRpc("do not have wallet file:" + walletFile)
 		}


### PR DESCRIPTION
1. Any operations based on wallet always need to input wallet password,
no default password now.

2. Provide -p option for node program to specify wallet password.

3. When using wallet from command line, provide two ways to input
walle password:
   a) specify with -p,--password <password string>
   b) when -p, --password is omitted, prompt user to input password

4. Wallet creation needs double confirmed password input when no
-p,--password is specified. If wallet already exists then program exits.

TODO: move sample transaction Bookkeeper to nodectl as a subcommand

Signed-off-by: Ziyan Zhou <zhouziyan@hotmail.com>