### PR TITLE
bug fix for blank log files

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -10,8 +10,7 @@ import (
 )
 
 func init() {
-	var path string = "./Log/"
-	log.CreatePrintLog(path)
+	log.Init()
 	crypto.SetAlg(config.Parameters.EncryptAlg)
 	//seed transaction nonce
 	rand.Seed(time.Now().UnixNano())

--- a/main.go
+++ b/main.go
@@ -23,8 +23,7 @@ const (
 )
 
 func init() {
-	log.CreatePrintLog(log.Path)
-
+	log.Init(log.Path, log.Stdout)
 	var coreNum int
 	if config.Parameters.MultiCoreNum > DefaultMultiCoreNum {
 		coreNum = int(config.Parameters.MultiCoreNum)
@@ -97,7 +96,7 @@ func main() {
 		isNeedNewFile := log.CheckIfNeedNewFile()
 		if isNeedNewFile == true {
 			log.ClosePrintLog()
-			log.CreatePrintLog(log.Path)
+			log.Init(log.Path, os.Stdout)
 		}
 	}
 


### PR DESCRIPTION
Changed log initialization function as following:
1. log.Init()
No log output will be printed. All outputs will be redirected to
/dev/null. nodectl will use this for disabling log function.

2. log.Init("./Log")
log will be saved to ./Log dirctory.

3. log.Init("./Log", stdout)
log will be saved to ./Log dirctory and printed to stdout.

Signed-off-by: Ziyan Zhou <zhouziyan@hotmail.com>