### PR TITLE
Only one-time hash is needed for wallet password

### DIFF
--- a/crypto/helper.go
+++ b/crypto/helper.go
@@ -1,26 +1,19 @@
 package crypto
 
 import (
-	"errors"
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
-	"bytes"
 	"crypto/sha256"
-	. "DNA/common"
+	"errors"
 )
 
-func ToAesKey( pwd []byte ) []byte {
-	pwdhash := sha256.Sum256(pwd)
-	pwdhash2 := sha256.Sum256(pwdhash[:])
-
-	// Fixme clean the password buffer
-	// ClearBytes(pwd,len(pwd))
-	ClearBytes(pwdhash[:],32)
-
-	return pwdhash2[:]
+func ToAesKey(pwd []byte) []byte {
+	passwordHash := sha256.Sum256(pwd)
+	return passwordHash[:]
 }
 
-func AesEncrypt(plaintext []byte, key []byte, iv[]byte) ([]byte, error) {
+func AesEncrypt(plaintext []byte, key []byte, iv []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, errors.New("invalid decrypt key")
@@ -35,7 +28,7 @@ func AesEncrypt(plaintext []byte, key []byte, iv[]byte) ([]byte, error) {
 	return ciphertext, nil
 }
 
-func AesDecrypt(ciphertext []byte, key []byte, iv[]byte) ([]byte, error) {
+func AesDecrypt(ciphertext []byte, key []byte, iv []byte) ([]byte, error) {
 
 	block, err := aes.NewCipher(key)
 	if err != nil {


### PR DESCRIPTION
No need to do double hash for wallet password, change to do hash only
one time.

Signed-off-by: Ziyan Zhou <zhouziyan@hotmail.com>