### PR TITLE
optimize log package

### DIFF
--- a/net/message/message.go
+++ b/net/message/message.go
@@ -196,8 +196,7 @@ func HandleNodeMsg(node Noder, buf []byte, len int) error {
 		return errors.New("Unexpected size of received message")
 	}
 
-	str := hex.EncodeToString(buf[:len])
-	log.Debug("Received data len: ", len, "\n", str)
+	log.Debugf("Received data len:  %d\n%x", len, buf[:len])
 
 	s, err := MsgType(buf)
 	if err != nil {

--- a/net/node/link.go
+++ b/net/node/link.go
@@ -8,7 +8,6 @@ import (
 	. "DNA/net/protocol"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -296,9 +295,7 @@ func TLSDial(nodeAddr string) (net.Conn, error) {
 }
 
 func (node *node) Tx(buf []byte) {
-	log.Debug()
-	str := hex.EncodeToString(buf)
-	log.Debug(fmt.Sprintf("TX buf length: %d\n%s", len(buf), str))
+	log.Debugf("TX buf length: %d\n%x", len(buf), buf)
 
 	_, err := node.conn.Write(buf)
 	if err != nil {


### PR DESCRIPTION
1. remove Mutex since method in std log package can be called simultaneously
2. log level check first to avoid unnecessary execution
3. provide Debugf, Infof, Warnf ... method to delay the execution of fmt.Sprintf.
4. remove some costly debug call in node/link.go, message.go

Signed-off-by: laizy <laizhichao@onchain.com>