### PR TITLE
Determine if block (with hash) is stored in db

### DIFF
--- a/core/ledger/ledger.go
+++ b/core/ledger/ledger.go
@@ -96,11 +96,7 @@ func (l *Ledger) GetBlockWithHash(hash Uint256) (*Block, error) {
 
 //BlockInLedger checks if the block existed in ledger
 func (l *Ledger) BlockInLedger(hash Uint256) bool {
-	bk, _ := l.Store.GetBlock(hash)
-	if bk == nil {
-		return false
-	}
-	return true
+	return l.Store.IsBlockInStore(hash)
 }
 
 //Get transaction with hash.

--- a/core/ledger/ledgerStore.go
+++ b/core/ledger/ledgerStore.go
@@ -45,4 +45,5 @@ type ILedgerStore interface {
 	GetUnspentFromProgramHash(programHash Uint160, assetid Uint256) ([]*tx.UTXOUnspent, error)
 
 	IsTxHashDuplicate(txhash Uint256) bool
+	IsBlockInStore(hash Uint256) bool
 }


### PR DESCRIPTION
Is more efficient use IsBlockInStore() instead of GetBlock().

Signed-off-by: zhengq1 <ljqlyy@gmail.com>