### PR TITLE
fix concurrency problem in connnectinglist cause of api design

### DIFF
--- a/net/node/link.go
+++ b/net/node/link.go
@@ -213,10 +213,10 @@ func (node *node) Connect(nodeAddr string) error {
 	if node.IsAddrInNbrList(nodeAddr) == true {
 		return nil
 	}
-	if node.IsAddrInConnectingList(nodeAddr) == true {
+	if added := node.SetAddrInConnectingList(nodeAddr); added == false {
 		return nil
 	}
-	node.SetAddrInConnectingList(nodeAddr)
+
 	isTls := Parameters.IsTLS
 	var conn net.Conn
 	var err error

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -92,21 +92,16 @@ func (node *node) IsAddrInNbrList(addr string) bool {
 	return false
 }
 
-func (node *node) IsAddrInConnectingList(addr string) bool {
-	node.ConnectingNodes.RLock()
-	defer node.ConnectingNodes.RUnlock()
-	for _, a := range node.ConnectingAddrs {
-		if strings.Compare(a, addr) == 0 {
-			return true
-		}
-	}
-	return false
-}
-
-func (node *node) SetAddrInConnectingList(addr string) {
+func (node *node) SetAddrInConnectingList(addr string) (added bool) {
 	node.ConnectingNodes.Lock()
 	defer node.ConnectingNodes.Unlock()
+	for _, a := range node.ConnectingAddrs {
+		if strings.Compare(a, addr) == 0 {
+			return false
+		}
+	}
 	node.ConnectingAddrs = append(node.ConnectingAddrs, addr)
+	return true
 }
 
 func (node *node) RemoveAddrInConnectingList(addr string) {

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -126,8 +126,7 @@ type Noder interface {
 	WaitForFourPeersStart()
 	GetFlightHeights() []uint32
 	IsAddrInNbrList(addr string) bool
-	IsAddrInConnectingList(addr string) bool
-	SetAddrInConnectingList(addr string)
+	SetAddrInConnectingList(addr string) bool
 	RemoveAddrInConnectingList(addr string)
 }
 


### PR DESCRIPTION
the addr existence test and add operation is not done in one atomic step,
which causes duplicated items in connectinglist，and multiple connecting .

Signed-off-by: laizy <laizhichao@onchain.com>