### PR TITLE
add nonce to BookKeeping transaction

### DIFF
--- a/consensus/dbft/dbftService.go
+++ b/consensus/dbft/dbftService.go
@@ -170,13 +170,14 @@ func (ds *DbftService) CheckSignatures() error {
 
 func (ds *DbftService) CreateBookkeepingTransaction(nonce uint64) *tx.Transaction {
 	log.Debug()
-
 	//TODO: sysfee
-
+	bookKeepingPayload := &payload.BookKeeping{
+		Nonce: uint64(time.Now().UnixNano()),
+	}
 	return &tx.Transaction{
 		TxType:         tx.BookKeeping,
-		PayloadVersion: 0x2,
-		Payload:        &payload.BookKeeping{},
+		PayloadVersion: tx.DefaultPayloadVersion,
+		Payload:        bookKeepingPayload,
 		Attributes:     []*tx.TxAttribute{},
 		UTXOInputs:     []*tx.UTXOTxInput{},
 		BalanceInputs:  []*tx.BalanceTxInput{},

--- a/core/ledger/block.go
+++ b/core/ledger/block.go
@@ -7,12 +7,16 @@ import (
 	"DNA/core/contract/program"
 	sig "DNA/core/signature"
 	tx "DNA/core/transaction"
+	"DNA/core/transaction/payload"
 	"DNA/crypto"
 	. "DNA/errors"
 	"DNA/vm"
 	"io"
 	"time"
 )
+
+const BlockVersion uint32 = 0
+const GenesisNonce uint64 = 2083236893
 
 type Block struct {
 	Blockdata    *Blockdata
@@ -144,51 +148,43 @@ func (b *Block) Type() InventoryType {
 }
 
 func GenesisBlockInit() (*Block, error) {
-	genesisBlock := new(Block)
-	//blockdata
-	genesisBlockdata := new(Blockdata)
-	genesisBlockdata.Version = uint32(0x00)
-	genesisBlockdata.PrevBlockHash = Uint256{}
-	genesisBlockdata.TransactionsRoot = Uint256{}
-	tm := time.Date(2017, time.February, 23, 0, 0, 0, 0, time.UTC)
-	genesisBlockdata.Timestamp = uint32(tm.Unix())
-	genesisBlockdata.Height = uint32(0)
-	genesisBlockdata.ConsensusData = uint64(2083236893)
+	//getBookKeeper
 	nextBookKeeper, err := GetBookKeeperAddress(StandbyBookKeepers)
 	if err != nil {
 		return nil, NewDetailErr(err, ErrNoCode, "[Block],GenesisBlockInit err with GetBookKeeperAddress")
 	}
-	genesisBlockdata.NextBookKeeper = nextBookKeeper
-
-	pg := new(program.Program)
-	pg.Code = []byte{'0'}
-	pg.Parameter = []byte{byte(vm.PUSHT)}
-	genesisBlockdata.Program = pg
-
-	//transaction
-	trans := new(tx.Transaction)
-	{
-		trans.TxType = tx.BookKeeping
-		trans.PayloadVersion = byte(0)
-		trans.Payload = nil
-		trans.Attributes = nil
-		trans.UTXOInputs = nil
-		trans.BalanceInputs = nil
-		trans.Outputs = nil
-		{
-			programHashes := []*program.Program{}
-			pg := new(program.Program)
-			pg.Code = []byte{'0'}
-			pg.Parameter = []byte{byte(vm.PUSHT)}
-			programHashes = append(programHashes, pg)
-			trans.Programs = programHashes
-		}
+	//blockdata
+	genesisBlockdata := &Blockdata{
+		Version:          BlockVersion,
+		PrevBlockHash:    Uint256{},
+		TransactionsRoot: Uint256{},
+		Timestamp:        uint32(uint32(time.Date(2017, time.February, 23, 0, 0, 0, 0, time.UTC).Unix())),
+		Height:           uint32(0),
+		ConsensusData:    GenesisNonce,
+		NextBookKeeper:   nextBookKeeper,
+		Program: &program.Program{
+			Code:      []byte{},
+			Parameter: []byte{byte(vm.PUSHT)},
+		},
 	}
-	genesisBlock.Blockdata = genesisBlockdata
-
-	genesisBlock.Transactions = append(genesisBlock.Transactions, trans)
-
-	//hashx := genesisBlock.Hash()
+	//transaction
+	trans := &tx.Transaction{
+		TxType:         tx.BookKeeping,
+		PayloadVersion: tx.DefaultPayloadVersion,
+		Payload: &payload.BookKeeping{
+			Nonce: GenesisNonce,
+		},
+		Attributes:    []*tx.TxAttribute{},
+		UTXOInputs:    []*tx.UTXOTxInput{},
+		BalanceInputs: []*tx.BalanceTxInput{},
+		Outputs:       []*tx.TxOutput{},
+		Programs:      []*program.Program{},
+	}
+	//block
+	genesisBlock := &Block{
+		Blockdata:    genesisBlockdata,
+		Transactions: []*tx.Transaction{trans},
+	}
 
 	return genesisBlock, nil
 }

--- a/core/transaction/payload/BookKeeping.go
+++ b/core/transaction/payload/BookKeeping.go
@@ -1,8 +1,12 @@
 package payload
 
-import "io"
+import (
+	"DNA/common/serialization"
+	"io"
+)
 
 type BookKeeping struct {
+	Nonce uint64
 }
 
 func (a *BookKeeping) Data() []byte {
@@ -10,10 +14,18 @@ func (a *BookKeeping) Data() []byte {
 }
 
 func (a *BookKeeping) Serialize(w io.Writer) error {
+	err := serialization.WriteUint64(w, a.Nonce)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
 func (a *BookKeeping) Deserialize(r io.Reader) error {
+	var err error
+	a.Nonce, err = serialization.ReadUint64(r)
+	if err != nil {
+		return err
+	}
 	return nil
 }
-

--- a/core/transaction/transaction.go
+++ b/core/transaction/transaction.go
@@ -16,6 +16,8 @@ import (
 	. "DNA/errors"
 )
 
+const DefaultPayloadVersion byte = 0x00
+
 //for different transaction types with different payload format
 //and transaction process methods
 type TransactionType byte

--- a/net/httpjsonrpc/TransPayloadToHex.go
+++ b/net/httpjsonrpc/TransPayloadToHex.go
@@ -13,6 +13,7 @@ type PayloadInfo interface{}
 
 //implement PayloadInfo define BookKeepingInfo
 type BookKeepingInfo struct {
+	Nonce uint64
 }
 
 //implement PayloadInfo define DeployCodeInfo
@@ -78,6 +79,9 @@ type PrivacyPayloadInfo struct {
 func TransPayloadToHex(p Payload) PayloadInfo {
 	switch object := p.(type) {
 	case *payload.BookKeeping:
+		obj := new(BookKeepingInfo)
+		obj.Nonce = object.Nonce
+		return obj
 	case *payload.BookKeeper:
 		obj := new(BookkeeperInfo)
 		encodedPubKey, _ := object.PubKey.EncodePoint(true)


### PR DESCRIPTION
as now BookKeeping with no nonce, so all the bookKeeping transaction
are the same hash and will overwrite the old bookKeeping transaction.

the genesisblock would be
{
    "Action": "getblockbyheight",
    "Desc": "SUCCESS",
    "Error": 0,
    "Result": {
        "Hash": "db40a76edf7035b3f2c307f0dd3e08f52b70a98dc8bee3089bfe7cbd80f0e7f6",
        "BlockData": {
            "Version": 0,
            "PrevBlockHash": "0000000000000000000000000000000000000000000000000000000000000000",
            "TransactionsRoot": "fb5bd72b2d6792d75dc2f1084ffa9e9f70ca85543c717a6b13d9959b452a57d6",
            "Timestamp": 1487808000,
            "Height": 0,
            "ConsensusData": 2083236893,
            "NextBookKeeper": "d02be7dd4f1f3dac60576ab00d8753b9151ed8c3",
            "Program": {
                "Code": "",
                "Parameter": "51"
            },
            "Hash": "db40a76edf7035b3f2c307f0dd3e08f52b70a98dc8bee3089bfe7cbd80f0e7f6"
        },
        "Transactions": [
            {
                "TxType": 0,
                "PayloadVersion": 0,
                "Payload": {
                    "Nonce": 2083236893
                },
                "Attributes": [],
                "UTXOInputs": [],
                "BalanceInputs": [],
                "Outputs": [],
                "Programs": [],
                "AssetOutputs": [],
                "AssetInputAmount": [],
                "AssetOutputAmount": [],
                "Hash": "d6572a459b95d9136b7a713c5485ca709f9efa4f08f1c25dd792672d2bd75bfb"
            }
        ]
    },
    "Version": "1.0.0"
}

Signed-off-by: luodanwg <luodan.wg@gmail.com>