### PR TITLE
fix blockCache memory leak

### DIFF
--- a/core/store/ChainStore/ChainStore.go
+++ b/core/store/ChainStore/ChainStore.go
@@ -1148,6 +1148,10 @@ func (bd *ChainStore) SaveBlock(b *Block, ledger *Ledger) error {
 	bd.mu.Lock()
 	defer bd.mu.Unlock()
 
+	if b.Blockdata.Height <= bd.currentBlockHeight {
+		return nil
+	}
+
 	if bd.blockCache[b.Hash()] == nil {
 		bd.blockCache[b.Hash()] = b
 	}


### PR DESCRIPTION
currently, the blockCache is used to hold blocks which has not been persisted, once the block persist is complete, it will be deleted from the blockCache, So add a  persisted block into the blockCache, it will not be removed forever, cause memory leak.

Signed-off-by: laizy <laizhichao@onchain.com>