### PR TITLE
fix keep-alive timeout: redesign the chainstore block processing logic

### DIFF
--- a/core/ledger/blockchain.go
+++ b/core/ledger/blockchain.go
@@ -62,7 +62,6 @@ func (bc *Blockchain) GetHeader(hash Uint256) (*Header, error) {
 }
 
 func (bc *Blockchain) SaveBlock(block *Block) error {
-	log.Debug()
 	log.Debugf("Save block, block hash %x", block.Hash())
 	err := DefaultLedger.Store.SaveBlock(block, DefaultLedger)
 	if err != nil {

--- a/core/ledger/ledgerStore.go
+++ b/core/ledger/ledgerStore.go
@@ -48,4 +48,5 @@ type ILedgerStore interface {
 
 	IsTxHashDuplicate(txhash Uint256) bool
 	IsBlockInStore(hash Uint256) bool
+	Close()
 }

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 	log.Info("0. Loading the Ledger")
 	ledger.DefaultLedger = new(ledger.Ledger)
 	ledger.DefaultLedger.Store, err = ChainStore.NewLedgerStore()
+	defer ledger.DefaultLedger.Store.Close()
 	if err != nil {
 		log.Fatal("open LedgerStore err:", err)
 		os.Exit(1)


### PR DESCRIPTION
redesign the chainstore block processing logic with multi-read, single write model
the original design of chainstore holds RWLock  too long, even a single call of GetHeaderHeight method may be blocked > 10s,
so ping message can not be constructed immediately;  SyncHeader, SyncBlk function will be blocked. and the timer in node.updateNodeInfo function will be delayed severely. causes keep-alive timeout and node reconnecting.

Signed-off-by: laizy <laizhichao@onchain.com>