### PR TITLE
add version control of payload.

### DIFF
--- a/core/transaction/payload/BookKeeper.go
+++ b/core/transaction/payload/BookKeeper.go
@@ -8,6 +8,8 @@ import (
 	"io"
 )
 
+const BookKeeperPayloadVersion byte = 0x00
+
 type BookKeeperAction byte
 
 const (
@@ -21,7 +23,7 @@ type BookKeeper struct {
 	Cert   []byte
 }
 
-func (self *BookKeeper) Data() []byte {
+func (self *BookKeeper) Data(version byte) []byte {
 	var buf bytes.Buffer
 	self.PubKey.Serialize(&buf)
 	buf.WriteByte(byte(self.Action))
@@ -30,13 +32,13 @@ func (self *BookKeeper) Data() []byte {
 	return buf.Bytes()
 }
 
-func (self *BookKeeper) Serialize(w io.Writer) error {
-	_, err := w.Write(self.Data())
+func (self *BookKeeper) Serialize(w io.Writer, version byte) error {
+	_, err := w.Write(self.Data(version))
 
 	return err
 }
 
-func (self *BookKeeper) Deserialize(r io.Reader) error {
+func (self *BookKeeper) Deserialize(r io.Reader, version byte) error {
 	self.PubKey = new(crypto.PubKey)
 	err := self.PubKey.DeSerialize(r)
 	if err != nil {

--- a/core/transaction/payload/BookKeeping.go
+++ b/core/transaction/payload/BookKeeping.go
@@ -6,16 +6,20 @@ import (
 )
 
 const BookKeepingPayloadVersion byte = 0x03
+const BookKeepingPayloadVersionBase byte = 0x02
 
 type BookKeeping struct {
 	Nonce uint64
 }
 
-func (a *BookKeeping) Data() []byte {
+func (a *BookKeeping) Data(version byte) []byte {
 	return []byte{0}
 }
 
-func (a *BookKeeping) Serialize(w io.Writer) error {
+func (a *BookKeeping) Serialize(w io.Writer, version byte) error {
+	if version == BookKeepingPayloadVersionBase {
+		return nil
+	}
 	err := serialization.WriteUint64(w, a.Nonce)
 	if err != nil {
 		return err
@@ -23,7 +27,10 @@ func (a *BookKeeping) Serialize(w io.Writer) error {
 	return nil
 }
 
-func (a *BookKeeping) Deserialize(r io.Reader) error {
+func (a *BookKeeping) Deserialize(r io.Reader, version byte) error {
+	if version == BookKeepingPayloadVersionBase {
+		return nil
+	}
 	var err error
 	a.Nonce, err = serialization.ReadUint64(r)
 	if err != nil {

--- a/core/transaction/payload/DataFile.go
+++ b/core/transaction/payload/DataFile.go
@@ -7,6 +7,8 @@ import (
 	"io"
 )
 
+const DataFilePayloadVersion byte = 0x00
+
 type DataFile struct {
 	IPFSPath string
 	Filename string
@@ -16,13 +18,13 @@ type DataFile struct {
 
 }
 
-func (a *DataFile) Data() []byte {
+func (a *DataFile) Data(version byte) []byte {
 	//TODO: implement RegisterRecord.Data()
 	return []byte{0}
 }
 
 // Serialize is the implement of SignableData interface.
-func (a *DataFile) Serialize(w io.Writer) error {
+func (a *DataFile) Serialize(w io.Writer, version byte) error {
 	err := serialization.WriteVarString(w, a.IPFSPath)
 	if err != nil {
 		return NewDetailErr(err, ErrNoCode, "[DataFileDetail], IPFSPath serialize failed.")
@@ -41,7 +43,7 @@ func (a *DataFile) Serialize(w io.Writer) error {
 }
 
 // Deserialize is the implement of SignableData interface.
-func (a *DataFile) Deserialize(r io.Reader) error {
+func (a *DataFile) Deserialize(r io.Reader, version byte) error {
 	var err error
 	a.IPFSPath, err = serialization.ReadVarString(r)
 	if err != nil {

--- a/core/transaction/payload/DeployCode.go
+++ b/core/transaction/payload/DeployCode.go
@@ -1,54 +1,56 @@
 package payload
 
 import (
-	. "DNA/core/code"
 	"DNA/common/serialization"
+	. "DNA/core/code"
 	"io"
 )
 
+const DeployCodePayloadVersion byte = 0x00
+
 type DeployCode struct {
-	Code 		*FunctionCode
-	Name 		string
-	CodeVersion 	string
-	Author		string
-	Email		string
-	Description 	string
+	Code        *FunctionCode
+	Name        string
+	CodeVersion string
+	Author      string
+	Email       string
+	Description string
 }
 
-func (dc *DeployCode) Data() []byte {
+func (dc *DeployCode) Data(version byte) []byte {
 	// TODO: Data()
 
 	return []byte{0}
 }
 
-func (dc *DeployCode) Serialize(w io.Writer) error {
+func (dc *DeployCode) Serialize(w io.Writer, version byte) error {
 
 	err := dc.Code.Serialize(w)
 	if err != nil {
 		return err
 	}
 
-	err = serialization.WriteVarString(w,dc.Name)
+	err = serialization.WriteVarString(w, dc.Name)
 	if err != nil {
 		return err
 	}
 
-	err = serialization.WriteVarString(w,dc.CodeVersion)
+	err = serialization.WriteVarString(w, dc.CodeVersion)
 	if err != nil {
 		return err
 	}
 
-	err = serialization.WriteVarString(w,dc.Author)
+	err = serialization.WriteVarString(w, dc.Author)
 	if err != nil {
 		return err
 	}
 
-	err = serialization.WriteVarString(w,dc.Email)
+	err = serialization.WriteVarString(w, dc.Email)
 	if err != nil {
 		return err
 	}
 
-	err = serialization.WriteVarString(w,dc.Description)
+	err = serialization.WriteVarString(w, dc.Description)
 	if err != nil {
 		return err
 	}
@@ -56,37 +58,36 @@ func (dc *DeployCode) Serialize(w io.Writer) error {
 	return nil
 }
 
-func (dc *DeployCode) Deserialize(r io.Reader) error {
+func (dc *DeployCode) Deserialize(r io.Reader, version byte) error {
 	err := dc.Code.Deserialize(r)
 	if err != nil {
 		return err
 	}
 
-	dc.Name,err = serialization.ReadVarString(r)
+	dc.Name, err = serialization.ReadVarString(r)
 	if err != nil {
 		return err
 	}
 
-	dc.CodeVersion,err = serialization.ReadVarString(r)
+	dc.CodeVersion, err = serialization.ReadVarString(r)
 	if err != nil {
 		return err
 	}
 
-	dc.Author,err = serialization.ReadVarString(r)
+	dc.Author, err = serialization.ReadVarString(r)
 	if err != nil {
 		return err
 	}
 
-	dc.Email,err = serialization.ReadVarString(r)
+	dc.Email, err = serialization.ReadVarString(r)
 	if err != nil {
 		return err
 	}
 
-	dc.Description,err = serialization.ReadVarString(r)
+	dc.Description, err = serialization.ReadVarString(r)
 	if err != nil {
 		return err
 	}
 
 	return nil
 }
-

--- a/core/transaction/payload/IssueAsset.go
+++ b/core/transaction/payload/IssueAsset.go
@@ -2,20 +2,21 @@ package payload
 
 import "io"
 
-type IssueAsset struct {
+const IssueAssetPayloadVersion byte = 0x00
 
+type IssueAsset struct {
 }
 
-func (a *IssueAsset) Data() []byte {
+func (a *IssueAsset) Data(version byte) []byte {
 	//TODO: implement IssueAsset.Data()
 	return []byte{0}
 
 }
 
-func (a *IssueAsset) Serialize(w io.Writer) error {
+func (a *IssueAsset) Serialize(w io.Writer, version byte) error {
 	return nil
 }
 
-func (a *IssueAsset) Deserialize(r io.Reader) error {
+func (a *IssueAsset) Deserialize(r io.Reader, version byte) error {
 	return nil
 }

--- a/core/transaction/payload/PrivacyPayload.go
+++ b/core/transaction/payload/PrivacyPayload.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+const PrivacyPayloadVersion byte = 0x00
+
 type EncryptedPayloadType byte
 
 type EncryptedPayload []byte
@@ -39,12 +41,12 @@ type PrivacyPayload struct {
 	EncryptAttr PayloadEncryptAttr
 }
 
-func (pp *PrivacyPayload) Data() []byte {
+func (pp *PrivacyPayload) Data(version byte) []byte {
 	//TODO: implement PrivacyPayload.Data()
 	return []byte{0}
 }
 
-func (pp *PrivacyPayload) Serialize(w io.Writer) error {
+func (pp *PrivacyPayload) Serialize(w io.Writer, version byte) error {
 	w.Write([]byte{byte(pp.PayloadType)})
 	err := serialization.WriteVarBytes(w, pp.Payload)
 	if err != nil {
@@ -56,7 +58,7 @@ func (pp *PrivacyPayload) Serialize(w io.Writer) error {
 	return err
 }
 
-func (pp *PrivacyPayload) Deserialize(r io.Reader) error {
+func (pp *PrivacyPayload) Deserialize(r io.Reader, version byte) error {
 	var PayloadType [1]byte
 	_, err := io.ReadFull(r, PayloadType[:])
 	if err != nil {

--- a/core/transaction/payload/Record.go
+++ b/core/transaction/payload/Record.go
@@ -7,18 +7,20 @@ import (
 	"io"
 )
 
+const RecordPayloadVersion byte = 0x00
+
 type Record struct {
 	RecordType string
 	RecordData []byte
 }
 
-func (a *Record) Data() []byte {
+func (a *Record) Data(version byte) []byte {
 	//TODO: implement RegisterRecord.Data()
 	return []byte{0}
 }
 
 // Serialize is the implement of SignableData interface.
-func (a *Record) Serialize(w io.Writer) error {
+func (a *Record) Serialize(w io.Writer, version byte) error {
 	err := serialization.WriteVarString(w, a.RecordType)
 	if err != nil {
 		return NewDetailErr(err, ErrNoCode, "[RecordDetail], RecordType serialize failed.")
@@ -31,7 +33,7 @@ func (a *Record) Serialize(w io.Writer) error {
 }
 
 // Deserialize is the implement of SignableData interface.
-func (a *Record) Deserialize(r io.Reader) error {
+func (a *Record) Deserialize(r io.Reader, version byte) error {
 	var err error
 	a.RecordType, err = serialization.ReadVarString(r)
 	if err != nil {

--- a/core/transaction/payload/RegisterAsset.go
+++ b/core/transaction/payload/RegisterAsset.go
@@ -4,26 +4,27 @@ import (
 	"DNA/common"
 	"DNA/core/asset"
 	"DNA/crypto"
-	"io"
 	. "DNA/errors"
-
+	"io"
 )
 
+const RegisterPayloadVersion byte = 0x00
+
 type RegisterAsset struct {
-	Asset      *asset.Asset
-	Amount     common.Fixed64
+	Asset  *asset.Asset
+	Amount common.Fixed64
 	//Precision  byte
 	Issuer     *crypto.PubKey
 	Controller common.Uint160
 }
 
-func (a *RegisterAsset) Data() []byte {
+func (a *RegisterAsset) Data(version byte) []byte {
 	//TODO: implement RegisterAsset.Data()
 	return []byte{0}
 
 }
 
-func (a *RegisterAsset) Serialize(w io.Writer)  error {
+func (a *RegisterAsset) Serialize(w io.Writer, version byte) error {
 	a.Asset.Serialize(w)
 	a.Amount.Serialize(w)
 	//w.Write([]byte{a.Precision})
@@ -32,7 +33,7 @@ func (a *RegisterAsset) Serialize(w io.Writer)  error {
 	return nil
 }
 
-func (a *RegisterAsset) Deserialize(r io.Reader) error {
+func (a *RegisterAsset) Deserialize(r io.Reader, version byte) error {
 
 	//asset
 	a.Asset = new(asset.Asset)
@@ -72,4 +73,3 @@ func (a *RegisterAsset) Deserialize(r io.Reader) error {
 	}
 	return nil
 }
-

--- a/core/transaction/payload/TransferAsset.go
+++ b/core/transaction/payload/TransferAsset.go
@@ -2,19 +2,21 @@ package payload
 
 import "io"
 
+const TransferAssetayloadVersion byte = 0x00
+
 type TransferAsset struct {
 }
 
-func (a *TransferAsset) Data() []byte {
+func (a *TransferAsset) Data(version byte) []byte {
 	//TODO: implement TransferAsset.Data()
 	return []byte{0}
 
 }
 
-func (a *TransferAsset) Serialize(w io.Writer) error {
+func (a *TransferAsset) Serialize(w io.Writer, version byte) error {
 	return nil
 }
 
-func (a *TransferAsset) Deserialize(r io.Reader) error {
+func (a *TransferAsset) Deserialize(r io.Reader, version byte) error {
 	return nil
 }

--- a/core/transaction/transaction.go
+++ b/core/transaction/transaction.go
@@ -36,12 +36,12 @@ const (
 //base on payload type which have different struture
 type Payload interface {
 	//  Get payload data
-	Data() []byte
+	Data(version byte) []byte
 
 	//Serialize payload data
-	Serialize(w io.Writer) error
+	Serialize(w io.Writer, version byte) error
 
-	Deserialize(r io.Reader) error
+	Deserialize(r io.Reader, version byte) error
 }
 
 //Transaction is used for carry information or action to Ledger
@@ -101,7 +101,7 @@ func (tx *Transaction) SerializeUnsigned(w io.Writer) error {
 	if tx.Payload == nil {
 		return errors.New("Transaction Payload is nil.")
 	}
-	tx.Payload.Serialize(w)
+	tx.Payload.Serialize(w, tx.PayloadVersion)
 	//[]*txAttribute
 	err := serialization.WriteVarUint(w, uint64(len(tx.Attributes)))
 	if err != nil {
@@ -203,8 +203,7 @@ func (tx *Transaction) DeserializeUnsignedWithoutType(r io.Reader) error {
 	default:
 		return errors.New("[Transaction],invalide transaction type.")
 	}
-
-	err = tx.Payload.Deserialize(r)
+	err = tx.Payload.Deserialize(r, tx.PayloadVersion)
 	if err != nil {
 		return NewDetailErr(err, ErrNoCode, "Payload Parse error")
 	}


### PR DESCRIPTION
Pass the version to payload, and payload can decide how to deserialize by version.

I have tested it on test environment. you also can check it by :
http://42.159.228.69:60334/api/v1/block/details/height/45221
http://42.159.228.69:60334/api/v1/block/details/height/45222

45221 block is the old payload version which have no nonce.
45221 block is the new payload version which have  nonce.
by version code, it can be deserialized according to type intelligence.
And keep the data compatible.



Signed-off-by: luodanwg <luodan.wg@gmail.com>