### PR TITLE
fixed GetTransactionResults bug.

### DIFF
--- a/core/transaction/transaction.go
+++ b/core/transaction/transaction.go
@@ -428,7 +428,12 @@ func (tx *Transaction) GetTransactionResults() (TransactionResult, error) {
 		if inputValue, ok := InputResult[outputAssetid]; ok {
 			result[outputAssetid] = inputValue - outputValue
 		} else {
-			result[outputAssetid] = outputValue * Fixed64(-1)
+			result[outputAssetid] -= outputValue
+		}
+	}
+	for inputAssetid, inputValue := range InputResult {
+		if _, exist := result[inputAssetid]; !exist {
+			result[inputAssetid] += inputValue
 		}
 	}
 	return result, nil


### PR DESCRIPTION
bug: GetTransactionResults() will return assets only occured in output.

pass the version to payload, and payload can decide how to Deserialize.

Signed-off-by: luodanwg <luodan.wg@gmail.com>