### PR TITLE
some code optimization

### DIFF
--- a/core/store/ChainStore/ChainStore.go
+++ b/core/store/ChainStore/ChainStore.go
@@ -1121,7 +1121,7 @@ func (bd *ChainStore) persistBlocks(ledger *Ledger) {
 
 		block, ok := bd.blockCache[hash]
 		if !ok {
-			log.Warn("[persistBlocks]: warn, blockCache not contain key hash.")
+			log.Debug("[persistBlocks]: debug, blockCache not contain key hash.")
 			break
 		}
 		err := bd.persist(block)

--- a/net/node/link.go
+++ b/net/node/link.go
@@ -93,9 +93,8 @@ func (node *node) rx() {
 			t := time.Now()
 			node.UpdateRXTime(t)
 			unpackNodeBuf(node, buf[0:len])
-			break
 		case io.EOF:
-			log.Error("Rx io.EOF ", err)
+			log.Error("Rx io.EOF: ", err, ", node id is ", node.GetID())
 			goto DISCONNECT
 		default:
 			log.Error("Read connection error ", err)


### PR DESCRIPTION
1. delete useless break
2. add node id prints when io.EOF exception happens.
3. change one warning to debug, since most of the time
   it is just a sign of end of cache.

Signed-off-by: Jin Qing <1091147665@qq.com>