### PR TITLE
Remove sync fail flag and fetch block header from neighbor node randomly

### DIFF
--- a/net/message/blockHdr.go
+++ b/net/message/blockHdr.go
@@ -10,6 +10,8 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
+	"math/rand"
+	"time"
 )
 
 type headersReq struct {
@@ -172,21 +174,20 @@ func SendMsgSyncHeaders(node Noder) {
 	if err != nil {
 		log.Error("failed build a new headersReq")
 	} else {
-		node.LocalNode().SetSyncHeaders(true)
-		node.SetSyncHeaders(true)
 		go node.Tx(buf)
 	}
 }
 
 func ReqBlkHdrFromOthers(node Noder) {
-	node.SetSyncFailed()
 	noders := node.LocalNode().GetNeighborNoder()
-	for _, noder := range noders {
-		if noder.IsSyncFailed() != true {
-			SendMsgSyncHeaders(noder)
-			break
-		}
+	rand.Seed(time.Now().UnixNano())
+	index := rand.Intn(len(noders))
+	if noders[index].GetID() == node.GetID() {
+		index = (index + 1) % len(noders)
 	}
+	n := noders[index]
+	SendMsgSyncHeaders(n)
+
 }
 
 func (msg blkHeader) Handle(node Noder) error {

--- a/net/node/infoUpdate.go
+++ b/net/node/infoUpdate.go
@@ -20,17 +20,14 @@ func (node *node) GetBlkHdrs() {
 	if node.local.GetNbrNodeCnt() < MINCONNCNT {
 		return
 	}
-
+	rand.Seed(time.Now().UnixNano())
 	noders := node.local.GetNeighborNoder()
-	for _, n := range noders {
-		if uint64(ledger.DefaultLedger.Store.GetHeaderHeight()) < n.GetHeight() {
-			if n.LocalNode().IsSyncFailed() == false {
-				SendMsgSyncHeaders(n)
-				n.StartRetryTimer()
-				break
-			}
-		}
-	}
+
+	index := rand.Intn(len(noders))
+	n := noders[index]
+	SendMsgSyncHeaders(n)
+	n.StartRetryTimer()
+
 }
 
 func (node *node) SyncBlk() {

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -47,7 +47,6 @@ type node struct {
 	/*
 	 * |--|--|--|--|--|--|isSyncFailed|isSyncHeaders|
 	 */
-	syncFlag                 uint8
 	TxNotifyChan             chan int
 	flightHeights            []uint32
 	lastContact              time.Time
@@ -385,36 +384,8 @@ func (node *node) WaitForFourPeersStart() {
 	}
 }
 
-func (node *node) IsSyncHeaders() bool {
-	if (node.syncFlag & 0x01) == 0x01 {
-		return true
-	} else {
-		return false
-	}
-}
-
-func (node *node) SetSyncHeaders(b bool) {
-	if b == true {
-		node.syncFlag = node.syncFlag | 0x01
-	} else {
-		node.syncFlag = node.syncFlag & 0xFE
-	}
-}
-
-func (node *node) IsSyncFailed() bool {
-	if (node.syncFlag & 0x02) == 0x02 {
-		return true
-	} else {
-		return false
-	}
-}
-
-func (node *node) SetSyncFailed() {
-	node.syncFlag = node.syncFlag | 0x02
-}
-
 func (node *node) StartRetryTimer() {
-	t := time.NewTimer(time.Second * 2)
+	t := time.NewTimer(time.Second * PERIODUPDATETIME)
 	node.TxNotifyChan = make(chan int, 1)
 	go func() {
 		select {

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -112,10 +112,6 @@ type Noder interface {
 	SyncNodeHeight()
 	CleanSubmittedTransactions(block *ledger.Block) error
 
-	IsSyncHeaders() bool
-	SetSyncHeaders(b bool)
-	IsSyncFailed() bool
-	SetSyncFailed()
 	StartRetryTimer()
 	StopRetryTimer()
 	GetNeighborNoder() []Noder


### PR DESCRIPTION
Sync fail flag lead to no hdr request issue when network poor, so remove it
Request hdr from a random select node

Signed-off-by: Xiang Fu <fuxiang@onchain.com>