### PR TITLE
fix header inconsist with context

### DIFF
--- a/consensus/dbft/consensusContext.go
+++ b/consensus/dbft/consensusContext.go
@@ -64,8 +64,8 @@ func (cxt *ConsensusContext) ChangeView(viewNum byte) {
 	if cxt.State == Initial {
 		cxt.Transactions = nil
 		cxt.Signatures = make([][]byte, len(cxt.BookKeepers))
+		cxt.header = nil
 	}
-	cxt.header = nil
 }
 
 func (cxt *ConsensusContext) MakeChangeView() *msg.ConsensusPayload {
@@ -82,15 +82,15 @@ func (cxt *ConsensusContext) MakeHeader() *ledger.Block {
 	if cxt.Transactions == nil {
 		return nil
 	}
-	txHash := []Uint256{}
-	for _, t := range cxt.Transactions {
-		txHash = append(txHash, t.Hash())
-	}
-	txRoot, err := crypto.ComputeRoot(txHash)
-	if err != nil {
-		return nil
-	}
 	if cxt.header == nil {
+		txHash := []Uint256{}
+		for _, t := range cxt.Transactions {
+			txHash = append(txHash, t.Hash())
+		}
+		txRoot, err := crypto.ComputeRoot(txHash)
+		if err != nil {
+			return nil
+		}
 		blockData := &ledger.Blockdata{
 			Version:          ContextVersion,
 			PrevBlockHash:    cxt.PrevHash,
@@ -190,6 +190,7 @@ func (cxt *ConsensusContext) Reset(client cl.Client, localNode net.Neter) {
 	bookKeeperLen := len(cxt.BookKeepers)
 	cxt.PrimaryIndex = cxt.Height % uint32(bookKeeperLen)
 	cxt.Transactions = nil
+	cxt.header = nil
 	cxt.Signatures = make([][]byte, bookKeeperLen)
 	cxt.ExpectedView = make([]byte, bookKeeperLen)
 
@@ -202,5 +203,4 @@ func (cxt *ConsensusContext) Reset(client cl.Client, localNode net.Neter) {
 		}
 	}
 
-	cxt.header = nil
 }

--- a/consensus/dbft/dbftService.go
+++ b/consensus/dbft/dbftService.go
@@ -386,6 +386,7 @@ func (ds *DbftService) PrepareRequestReceived(payload *msg.ConsensusPayload, mes
 	ds.context.Timestamp = payload.Timestamp
 	ds.context.Nonce = message.Nonce
 	ds.context.Transactions = message.Transactions
+	ds.context.header = nil
 
 	//block header verification
 	_, err = va.VerifySignature(ds.context.MakeHeader(), ds.context.BookKeepers[payload.BookKeeperIndex], message.Signature)
@@ -552,6 +553,7 @@ func (ds *DbftService) Timeout() {
 			for _, tx := range transactionsPool {
 				ds.context.Transactions = append(ds.context.Transactions, tx)
 			}
+			ds.context.header = nil
 			//build block and sign
 			block := ds.context.MakeHeader()
 			account, _ := ds.Client.GetAccount(ds.context.BookKeepers[ds.context.BookKeeperIndex]) //TODO: handle error


### PR DESCRIPTION
the header is used as cache to reduce the computation of MerkleTree.
when change context , the header should also be cleared

Signed-off-by: laizy <laizhichao@onchain.com>