### PR TITLE
Fix crypto.Verify issue.

### DIFF
--- a/core/validation/validation.go
+++ b/core/validation/validation.go
@@ -55,8 +55,8 @@ func VerifySignableData(signableData sig.SignableData) (bool, error) {
 }
 
 func VerifySignature(signableData sig.SignableData, pubkey *crypto.PubKey, signature []byte) (bool, error) {
-	ok, err := crypto.Verify(*pubkey, sig.GetHashData(signableData), signature)
-	if !ok {
+	err := crypto.Verify(*pubkey, sig.GetHashData(signableData), signature)
+	if err != nil {
 		return false, NewDetailErr(err, ErrNoCode, "[Validation], VerifySignature failed.")
 	} else {
 		return true, nil

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -87,11 +87,11 @@ func Sign(privateKey []byte, data []byte) ([]byte, error) {
 	return signature, nil
 }
 
-func Verify(publicKey PubKey, data []byte, signature []byte) (bool, error) {
+func Verify(publicKey PubKey, data []byte, signature []byte) error {
 	len := len(signature)
 	if len != util.SIGNATURELEN {
 		fmt.Printf("Unknown signature length %d\n", len)
-		return false, errors.New("Unknown signature length")
+		return errors.New("Unknown signature length")
 	}
 
 	r := new(big.Int).SetBytes(signature[:len/2])

--- a/crypto/p256r1/p256r1.go
+++ b/crypto/p256r1/p256r1.go
@@ -45,7 +45,7 @@ func Sign(algSet *util.CryptoAlgSet, priKey []byte, data []byte) (*big.Int, *big
 	return r, s, nil
 }
 
-func Verify(algSet *util.CryptoAlgSet, X *big.Int, Y *big.Int, data []byte, r, s *big.Int) (bool, error) {
+func Verify(algSet *util.CryptoAlgSet, X *big.Int, Y *big.Int, data []byte, r, s *big.Int) error {
 	digest := util.Hash(data)
 
 	pub := new(ecdsa.PublicKey)
@@ -54,5 +54,9 @@ func Verify(algSet *util.CryptoAlgSet, X *big.Int, Y *big.Int, data []byte, r, s
 	pub.X = new(big.Int).Set(X)
 	pub.Y = new(big.Int).Set(Y)
 
-	return ecdsa.Verify(pub, digest[:], r, s), nil
+	if ecdsa.Verify(pub, digest[:], r, s) {
+		return nil
+	} else {
+		return errors.New("[Validation], Verify failed.")
+	}
 }

--- a/crypto/sm2/sm2.go
+++ b/crypto/sm2/sm2.go
@@ -151,21 +151,21 @@ func Sign(algSet *util.CryptoAlgSet, priKey []byte, data []byte) (r *big.Int, s 
 	return
 }
 
-func Verify(algSet *util.CryptoAlgSet, publicKeyX *big.Int, publicKeyY *big.Int, data []byte, r, s *big.Int) (bool, error) {
+func Verify(algSet *util.CryptoAlgSet, publicKeyX *big.Int, publicKeyY *big.Int, data []byte, r, s *big.Int) error {
 	c := algSet.Curve
 	N := c.Params().N
 
 	if r.Sign() <= 0 || s.Sign() <= 0 {
-		return false, errors.New("SM2 signature contained zero or negative values")
+		return errors.New("SM2 signature contained zero or negative values")
 	}
 	if r.Cmp(N) >= 0 || s.Cmp(N) >= 0 {
-		return false, errors.New("SM2 signature contained zero or negative values")
+		return errors.New("SM2 signature contained zero or negative values")
 	}
 
 	t := new(big.Int).Add(r, s)
 	t.Mod(t, N)
 	if N.Sign() == 0 {
-		return false, errors.New("SM2 Params N contained zero or negative values")
+		return errors.New("SM2 Params N contained zero or negative values")
 	}
 
 	var x *big.Int
@@ -181,7 +181,11 @@ func Verify(algSet *util.CryptoAlgSet, publicKeyX *big.Int, publicKeyY *big.Int,
 	e := new(big.Int).SetBytes(hash[:])
 	x.Add(x, e)
 	x.Mod(x, N)
-	return x.Cmp(r) == 0, nil
+	if x.Cmp(r) == 0{
+		return nil
+	}else {
+		return errors.New("[Validation], Verify failed.")
+	}
 }
 
 // Combine the raw data with user ID, curve parameters and public key

--- a/vm/ECDsaCrypto.go
+++ b/vm/ECDsaCrypto.go
@@ -30,10 +30,9 @@ func (c * ECDsaCrypto) VerifySignature(message []byte,signature []byte, pubkey [
 		return false,NewDetailErr(errors.New("[ECDsaCrypto], crypto.DecodePoint failed."), ErrNoCode, "")
 	}
 
-	temp ,err := crypto.Verify(*pk, message,signature)
-	if !temp {
+	err = crypto.Verify(*pk, message,signature)
+	if err != nil {
 		return false,NewDetailErr(errors.New("[ECDsaCrypto], VerifySignature failed."), ErrNoCode, "")
 	}
-
 	return true,nil
 }


### PR DESCRIPTION
1.Reduce the return value of crypto.Verify() from 2 to 1 so that the
result can be easily to judged. if return value "error" is nil
verifysignature successed, otherwise failed.

Signed-off-by: XiaoJie Guo <guoxiaojie@onchain.com>