### PR TITLE
Fix the “GetBlockWithHeight failed” error

### DIFF
--- a/net/message/blockHdr.go
+++ b/net/message/blockHdr.go
@@ -10,8 +10,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
-	"math/rand"
-	"time"
 )
 
 type headersReq struct {
@@ -178,33 +176,15 @@ func SendMsgSyncHeaders(node Noder) {
 	}
 }
 
-func ReqBlkHdrFromOthers(node Noder) {
-	noders := node.LocalNode().GetNeighborNoder()
-	if len(noders) == 0 {
-		return
-	}
-	rand.Seed(time.Now().UnixNano())
-	index := rand.Intn(len(noders))
-	if noders[index].GetID() == node.GetID() {
-		index = (index + 1) % len(noders)
-	}
-	n := noders[index]
-	SendMsgSyncHeaders(n)
-
-}
-
 func (msg blkHeader) Handle(node Noder) error {
 	log.Debug()
-	node.StopRetryTimer()
 	err := ledger.DefaultLedger.Store.AddHeaders(msg.blkHdr, ledger.DefaultLedger)
 	if err != nil {
 		log.Warn("Add block Header error")
-		ReqBlkHdrFromOthers(node)
 		return errors.New("Add block Header error, send new header request to another node\n")
 	}
 	if msg.cnt == MAXBLKHDRCNT {
 		SendMsgSyncHeaders(node)
-		node.StartRetryTimer()
 	}
 	return nil
 }

--- a/net/node/infoUpdate.go
+++ b/net/node/infoUpdate.go
@@ -20,14 +20,24 @@ func (node *node) GetBlkHdrs() {
 	if node.local.GetNbrNodeCnt() < MINCONNCNT {
 		return
 	}
-	rand.Seed(time.Now().UnixNano())
 	noders := node.local.GetNeighborNoder()
-
-	index := rand.Intn(len(noders))
-	n := noders[index]
+	if len(noders) == 0 {
+		return
+	}
+	nodelist := []Noder{}
+	for _, v := range noders {
+		if uint64(ledger.DefaultLedger.Store.GetHeaderHeight()) < v.GetHeight() {
+			nodelist = append(nodelist, v)
+		}
+	}
+	ncout := len(nodelist)
+	if ncout == 0 {
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	index := rand.Intn(ncout)
+	n := nodelist[index]
 	SendMsgSyncHeaders(n)
-	n.StartRetryTimer()
-
 }
 
 func (node *node) SyncBlk() {

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -47,7 +47,6 @@ type node struct {
 	/*
 	 * |--|--|--|--|--|--|isSyncFailed|isSyncHeaders|
 	 */
-	TxNotifyChan             chan int
 	flightHeights            []uint32
 	lastContact              time.Time
 	nodeDisconnectSubscriber events.Subscriber
@@ -393,23 +392,6 @@ func (node *node) WaitForFourPeersStart() {
 		}
 		<-time.After(2 * time.Second)
 	}
-}
-
-func (node *node) StartRetryTimer() {
-	t := time.NewTimer(time.Second * PERIODUPDATETIME)
-	node.TxNotifyChan = make(chan int, 1)
-	go func() {
-		select {
-		case <-t.C:
-			ReqBlkHdrFromOthers(node)
-		case <-node.TxNotifyChan:
-			t.Stop()
-		}
-	}()
-}
-
-func (node *node) StopRetryTimer() {
-	node.TxNotifyChan <- 1
 }
 
 func (node *node) StoreFlightHeight(height uint32) {

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -114,8 +114,6 @@ type Noder interface {
 	SyncNodeHeight()
 	CleanSubmittedTransactions(block *ledger.Block) error
 
-	StartRetryTimer()
-	StopRetryTimer()
 	GetNeighborNoder() []Noder
 	GetNbrNodeCnt() uint32
 	StoreFlightHeight(height uint32)


### PR DESCRIPTION
The root cause is the new header sync logic not check the height of remote node.
So if node be acquired a higher block the error info print.

Signed-off-by: Xiang Fu <fuxiang@onchain.com>