### PR TITLE
Change the max header count when sync with others, reduce the node load

### DIFF
--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -38,7 +38,7 @@ const (
 	HASHLEN       = 32 // hash length in byte
 	MSGHDRLEN     = 24
 	NETMAGIC      = 0x74746e41
-	MAXBLKHDRCNT  = 2000
+	MAXBLKHDRCNT  = 500
 	MAXINVHDRCNT  = 500
 	DIVHASHLEN    = 5
 	MINCONNCNT    = 3


### PR DESCRIPTION
The synchronized node would running into unstable state under heave sync request

Signed-off-by: Xiang Fu <fuxiang@onchain.com>