### PR TITLE
Limit the concurrent sync header responses

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -40,6 +40,7 @@ type Configuration struct {
 	EncryptAlg      string   `json:"EncryptAlg"`
 	MaxLogSize      int64    `json:"MaxLogSize"`
 	MaxTxInBlock    int      `json:"MaxTransactionInBlock"`
+	MaxHdrSyncReqs  int      `json:"MaxConcurrentSyncHeaderReqs"`
 }
 
 type ConfigFile struct {

--- a/net/message/blockHdr.go
+++ b/net/message/blockHdr.go
@@ -151,6 +151,7 @@ func (msg headersReq) Handle(node Noder) error {
 	log.Debug()
 	// lock
 	node.LocalNode().AcqSyncReqSem()
+	defer node.LocalNode().RelSyncReqSem()
 	var startHash [HASHLEN]byte
 	var stopHash [HASHLEN]byte
 	startHash = msg.p.hashStart
@@ -158,16 +159,13 @@ func (msg headersReq) Handle(node Noder) error {
 	//FIXME if HeaderHashCount > 1
 	headers, cnt, err := GetHeadersFromHash(startHash, stopHash)
 	if err != nil {
-		node.LocalNode().RelSyncReqSem()
 		return err
 	}
 	buf, err := NewHeaders(headers, cnt)
 	if err != nil {
-		node.LocalNode().RelSyncReqSem()
 		return err
 	}
 	go node.Tx(buf)
-	node.LocalNode().RelSyncReqSem()
 	return nil
 }
 

--- a/net/message/blockHdr.go
+++ b/net/message/blockHdr.go
@@ -150,6 +150,7 @@ blkHdrErr:
 func (msg headersReq) Handle(node Noder) error {
 	log.Debug()
 	// lock
+	node.LocalNode().AcqSyncReqSem()
 	var startHash [HASHLEN]byte
 	var stopHash [HASHLEN]byte
 	startHash = msg.p.hashStart
@@ -157,13 +158,16 @@ func (msg headersReq) Handle(node Noder) error {
 	//FIXME if HeaderHashCount > 1
 	headers, cnt, err := GetHeadersFromHash(startHash, stopHash)
 	if err != nil {
+		node.LocalNode().RelSyncReqSem()
 		return err
 	}
 	buf, err := NewHeaders(headers, cnt)
 	if err != nil {
+		node.LocalNode().RelSyncReqSem()
 		return err
 	}
 	go node.Tx(buf)
+	node.LocalNode().RelSyncReqSem()
 	return nil
 }
 

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -24,6 +24,15 @@ import (
 	"time"
 )
 
+type Semaphore chan struct{}
+
+func MakeSemaphore(n int) Semaphore {
+	return make(chan struct{}, n)
+}
+
+func (s Semaphore) acquire() { s <- struct{}{} }
+func (s Semaphore) release() { <-s }
+
 type node struct {
 	//sync.RWMutex	//The Lock not be used as expected to use function channel instead of lock
 	state     uint32 // node state
@@ -53,6 +62,7 @@ type node struct {
 	tryTimes                 uint32
 	ConnectingNodes
 	RetryConnAddrs
+	SyncReqSem Semaphore
 }
 
 type RetryConnAddrs struct {
@@ -154,6 +164,13 @@ func InitNode(pubKey *crypto.PubKey) Noder {
 	} else if Parameters.NodeType == VERIFYNODENAME {
 		n.services = uint64(VERIFYNODE)
 	}
+
+	if Parameters.MaxHdrSyncReqs <= 0 {
+		n.SyncReqSem = MakeSemaphore(MAXSYNCHDRREQ)
+	} else {
+		n.SyncReqSem = MakeSemaphore(Parameters.MaxHdrSyncReqs)
+	}
+
 	n.link.port = uint16(Parameters.NodePort)
 	n.relay = true
 	// TODO is it neccessary to init the rand seed here?
@@ -461,4 +478,11 @@ func (node *node) RemoveFromRetryList(addr string) {
 		}
 	}
 
+}
+func (node *node) AcqSyncReqSem() {
+	node.SyncReqSem.acquire()
+}
+
+func (node *node) RelSyncReqSem() {
+	node.SyncReqSem.release()
 }

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -57,6 +57,7 @@ const (
 	CONNMONITOR      = 6
 	CONNMAXBACK      = 4000
 	MAXRETRYCOUNT    = 3
+	MAXSYNCHDRREQ    = 2 //Max Concurrent Sync Header Request
 )
 
 // The node state
@@ -131,6 +132,8 @@ type Noder interface {
 	RemoveAddrInConnectingList(addr string)
 	AddInRetryList(addr string)
 	RemoveFromRetryList(addr string)
+	AcqSyncReqSem()
+	RelSyncReqSem()
 }
 
 func (msg *NodeAddr) Deserialization(p []byte) error {


### PR DESCRIPTION
Too many concurrent handle of sync header would lower the node`s performance.

Signed-off-by: Xiang Fu <fuxiang@onchain.com>