### PR TITLE
Fix double spent issue in transaction pool

### DIFF
--- a/errors/errcode.go
+++ b/errors/errcode.go
@@ -31,14 +31,35 @@ const (
 func (err ErrCode) Error() string {
 	switch err {
 	case ErrNoCode:
-		return "No error code"
+		return "no error code"
 	case ErrNoError:
-		return "Not an error"
+		return "not an error"
 	case ErrUnknown:
-		return "Unknown error"
+		return "unknown error"
 	case ErrDuplicatedTx:
-		return "There are duplicated Transactions"
-
+		return "duplicated transaction detected"
+	case ErrDuplicateInput:
+		return "duplicated transaction input detected"
+	case ErrAssetPrecision:
+		return "invalid asset precision"
+	case ErrTransactionBalance:
+		return "transaction balance unmatched"
+	case ErrAttributeProgram:
+		return "attribute program error"
+	case ErrTransactionContracts:
+		return "invalid transaction contract"
+	case ErrTransactionPayload:
+		return "invalid transaction payload"
+	case ErrDoubleSpend:
+		return "double spent transaction detected"
+	case ErrTxHashDuplicate:
+		return "duplicated transaction hash detected"
+	case ErrStateUpdaterVaild:
+		return "invalid state updater"
+	case ErrSummaryAsset:
+		return "invalid summary asset"
+	case ErrXmitFail:
+		return "transmit error"
 	}
 
 	return fmt.Sprintf("Unknown error? Error code = %d", err)

--- a/net/httpjsonrpc/interfaces.go
+++ b/net/httpjsonrpc/interfaces.go
@@ -269,7 +269,7 @@ func sendRawTransaction(params []interface{}) map[string]interface{} {
 		}
 		hash = txn.Hash()
 		if errCode := VerifyAndSendTx(&txn); errCode != ErrNoError {
-			return DnaRpcInternalError
+			return DnaRpc(errCode.Error())
 		}
 	default:
 		return DnaRpcInvalidParameter

--- a/net/node/transactionPool.go
+++ b/net/node/transactionPool.go
@@ -9,6 +9,7 @@ import (
 	"DNA/core/transaction/payload"
 	va "DNA/core/validation"
 	. "DNA/errors"
+	"errors"
 	"fmt"
 	"sync"
 )
@@ -91,11 +92,10 @@ func (this *TXNPool) GetTransaction(hash common.Uint256) *transaction.Transactio
 
 //verify transaction with txnpool
 func (this *TXNPool) verifyTransactionWithTxnPool(txn *transaction.Transaction) bool {
-	//check weather have duplicate UTXO input,if occurs duplicate, just keep the latest txn.
-	ok, duplicateTxn := this.apendToUTXOPool(txn)
-	if !ok && duplicateTxn != nil {
-		log.Info(fmt.Sprintf("txn=%x duplicateTxn UTXO occurs with txn in pool=%x,keep the latest one.", txn.Hash(), duplicateTxn.Hash()))
-		this.removeTransaction(duplicateTxn)
+	// check if the transaction includes double spent UTXO inputs
+	if err := this.verifyDoubleSpend(txn); err != nil {
+		log.Info(err)
+		return false
 	}
 	//check issue transaction weather occur exceed issue range.
 	if ok := this.summaryAssetIssueAmount(txn); !ok {
@@ -130,19 +130,25 @@ func (this *TXNPool) removeTransaction(txn *transaction.Transaction) {
 }
 
 //check and add to utxo list pool
-func (this *TXNPool) apendToUTXOPool(txn *transaction.Transaction) (bool, *transaction.Transaction) {
+func (this *TXNPool) verifyDoubleSpend(txn *transaction.Transaction) error {
 	reference, err := txn.GetReference()
 	if err != nil {
-		return false, nil
+		return err
 	}
-	for k, _ := range reference {
-		t := this.getInputUTXOList(k)
-		if t != nil {
-			return false, t
+	inputs := []*transaction.UTXOTxInput{}
+	for k := range reference {
+		if txn := this.getInputUTXOList(k); txn != nil {
+			return errors.New(fmt.Sprintf("double spent UTXO inputs detected, "+
+				"transaction hash: %x, input: %s, index: %s",
+				txn.Hash(), k.ToString()[:64], k.ToString()[64:]))
 		}
-		this.addInputUTXOList(txn, k)
+		inputs = append(inputs, k)
 	}
-	return true, nil
+	for _, v := range inputs {
+		this.addInputUTXOList(txn, v)
+	}
+
+	return nil
 }
 
 //clean txnpool utxo map


### PR DESCRIPTION
Removed duplicated inputs from UTXO Inputs List of transaction pool
when remove double spent transaction, which will cause double spend
when any transactions still refer to the inputs removed before.

Signed-off-by: Ziyan Zhou <zhouziyan@hotmail.com>